### PR TITLE
Add obvious-ci docker source

### DIFF
--- a/obvious-ci/Dockerfile
+++ b/obvious-ci/Dockerfile
@@ -1,0 +1,67 @@
+FROM centos:6
+
+MAINTAINER Phil Elson <pelson.pub@gmail.com>
+
+
+# Set an encoding to make things work smoothly.
+ENV LANG en_US.UTF-8
+
+# Install basic requirements.
+RUN yum update -y && \
+    yum install -y \
+                   bzip2 \
+                   gcc-c++ \
+                   git \
+                   make \
+                   patch \
+                   tar \
+                   which \
+                   libXext-devel \
+                   libXrender-devel \
+                   libSM-devel \
+                   libX11-devel \
+                   mesa-libGL-devel && \
+    yum clean all
+
+# Install devtoolset 2.
+RUN yum update -y && \
+    yum install -y \
+                   centos-release-scl \
+                   yum-utils && \
+    yum-config-manager --add-repo http://people.centos.org/tru/devtools-2/devtools-2.repo && \
+    yum update -y && \
+    yum install -y \
+                   devtoolset-2-binutils \
+                   devtoolset-2-gcc \
+                   devtoolset-2-gcc-c++ && \
+    yum clean all
+
+# Download and install tini for zombie reaping.
+RUN curl -s -L -O https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
+    openssl md5 tini | grep 596b898785d2f169ec969445087c14d6 && \
+    chmod +x tini && \
+    mv tini /usr/local/bin
+
+# Install the latest Miniconda with Python 3 and update everything.
+RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
+    export PATH=/opt/conda/bin:$PATH && \
+    conda config --set show_channel_urls True && \
+    conda update --all --yes && conda clean -tipsy
+
+# Install Obvious-CI.
+RUN export PATH="/opt/conda/bin:${PATH}" && \
+    conda install --yes -c pelson/channel/development obvious-ci && \
+    obvci_install_conda_build_tools.py
+
+# udunits2.
+# libtool texinfo
+# RUN yum install -y expat-devel
+
+COPY entrypoint_source /opt/docker/bin/entrypoint_source
+COPY entrypoint /opt/docker/bin/entrypoint
+
+# Ensure that all containers start with tini and the user selected process.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
+ENTRYPOINT [ "/usr/local/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]

--- a/obvious-ci/entrypoint
+++ b/obvious-ci/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Source everything that needs to be.
+. /opt/docker/bin/entrypoint_source
+
+# Run whatever the user wants.
+exec "$@"

--- a/obvious-ci/entrypoint_source
+++ b/obvious-ci/entrypoint_source
@@ -1,0 +1,11 @@
+# Enable the compiler toolset.
+#
+# Must do this before activating conda or
+# the system Python interpreter is not used.
+# This is a problem for many reasons. One being
+# that the Python scripts used to activate the
+# toolset are not Python 3 compatible.
+. scl_source enable devtoolset-2
+
+# Activate the `root` conda environment.
+. /opt/conda/bin/activate root


### PR DESCRIPTION
@pelson, as [discussed]( https://github.com/conda-forge/conda-forge.github.io/pull/121/files#diff-e482962a4824eb0dcd693fea95aca49eR116 ) after the general meeting on the 2016-04-29, I am adding this PR to add the `obvious-ci` docker image here. This is being removed it from the [Obvious-CI repo]( https://github.com/pelson/Obvious-CI ) in this PR ( https://github.com/pelson/Obvious-CI/pull/65 ). Also, will setup a Docker Hub autobuild in a moment. Already tried building this locally from this repo here and it works fine.