### PR TITLE
Update linux-anvil maintainer

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:6
 
-MAINTAINER Phil Elson <pelson.pub@gmail.com>
+MAINTAINER conda-forge <conda-forge@googlegroups.com>
 
 
 # Set an encoding to make things work smoothly.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/docker-images/issues/7

Update the maintainer of `linux-anvil` to be the organization.