### PR TITLE
Configure CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![CircleCI](https://circleci.com/gh/conda-forge/docker-images/tree/master.svg?style=svg)](https://circleci.com/gh/conda-forge/docker-images/tree/master)
+
 # docker-images
 Repository to host the Docker images files used in conda-forge

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+
+test:
+  override:
+    - docker build -t condaforge/linux-anvil linux-anvil


### PR DESCRIPTION
Configure the repo so that it can perform CI with CircleCI. This will let us test the builds of our images quickly and will avoid having to build them by hand locally. Hopefully with this change we can have a better idea of whether a proposed change is working without needing to spend cycles building it locally. To start of the CI, this just tries to get the image built. In the future, this could be used to test image(s) built to make sure they behave ok.