### PR TITLE
Add a Dockerfile to mirror quay.io

### DIFF
--- a/linux-anvil-mirror/Dockerfile
+++ b/linux-anvil-mirror/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/condaforge/linux-anvil:latest


### PR DESCRIPTION
Partially resolves https://github.com/conda-forge/docker-images/issues/14

This adds a `Dockerfile` that merely pulls the [image]( https://quay.io/repository/condaforge/linux-anvil ) we are building on [quay.io]( https://quay.io/ ). The purpose of doing this is we could change our Docker Hub build to use this instead of building the image from scratch. Thus we will not need to go through and change our `FROM` commands, but we can actually build our image again. This is increasingly important as we are needing to make changes to it.

Additionally, I have enabled a webhook on the Docker Hub side and configured quay.io to post using that webhook after pushing an image. I just tested this system and it appears to work. So, when we merge something here it will be rebuilt on quay.io and once built will trigger a build on DockerHub that will pull in this image.

The last piece that we need to do after merging this is to change the directory that DockerHub uses for the `Dockerfile` to point to this directory that we are adding.

cc @pelson @jjhelmus @msarahan @ocefpaf