### PR TITLE
Bust the cache in linux-anvil

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER conda-forge <conda-forge@googlegroups.com>
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 
+# Add a timestamp for the build. Also, bust the cache.
+ADD http://www.timeapi.org/utc/now /opt/docker/etc/timestamp
+
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \


### PR DESCRIPTION
This adds a step that always busts the cache. Based on a [workaround]( https://github.com/docker/docker/pull/10682#issuecomment-178810479 ) offered in-place of the unaccepted `NOCACHE` command. The purpose of this step is to ensure that we are not re-using cached downloads. We accomplish this by `ADD`ing a file that we download from a URL that always changes. Namely we add a file that contains the current time. As a result, we will have a different hash for this layer each time and will need to generate every subsequent layer from scratch.