### PR TITLE
Fix NOKEY warning in linux-anvil

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -9,6 +9,9 @@ ENV LANG en_US.UTF-8
 # Add a timestamp for the build. Also, bust the cache.
 ADD http://www.timeapi.org/utc/now /opt/docker/etc/timestamp
 
+# Resolves a nasty NOKEY warning that appears when using yum.
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \


### PR DESCRIPTION
We are getting a `NOKEY` warning during the linux-anvil build when running `yum`. This should ensure the key is imported so that this warning is not issued.

The warning this avoids is shown below and can be seen in this [log]( https://circleci.com/gh/conda-forge/docker-images/3 ). Also, it can be seen in [quay]( https://quay.io/repository/condaforge/linux-anvil/build/cf7d2de8-41a3-4557-a141-b1b1e4b7dc19 ) too.

```
warning: rpmts_HdrFromFdno: Header V3 RSA/SHA1 Signature, key ID c105b9de: NOKEY
```