### PR TITLE
WIP: Add CUDA and cuDNN

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,4 @@ dependencies:
 test:
   override:
     - docker build -t condaforge/linux-anvil linux-anvil
+    - docker build -t condaforge/linux-anvil-cudnn linux-anvil-cudnn

--- a/linux-anvil-cudnn/Dockerfile
+++ b/linux-anvil-cudnn/Dockerfile
@@ -1,0 +1,79 @@
+FROM nvidia/cuda:7.5-cudnn5-devel-centos6
+
+MAINTAINER conda-forge <conda-forge@googlegroups.com>
+
+
+# Set an encoding to make things work smoothly.
+ENV LANG en_US.UTF-8
+
+# Add a timestamp for the build. Also, bust the cache.
+ADD http://www.timeapi.org/utc/now /opt/docker/etc/timestamp
+
+# Resolves a nasty NOKEY warning that appears when using yum.
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# Install basic requirements.
+RUN yum update -y && \
+    yum install -y \
+                   bzip2 \
+                   gcc-c++ \
+                   make \
+                   patch \
+                   tar \
+                   which \
+                   libXext-devel \
+                   libXrender-devel \
+                   libSM-devel \
+                   libX11-devel \
+                   mesa-libGL-devel && \
+    yum clean all
+
+# Install devtoolset 2.
+RUN yum update -y && \
+    yum install -y \
+                   centos-release-scl \
+                   yum-utils && \
+    yum-config-manager --add-repo http://people.centos.org/tru/devtools-2/devtools-2.repo && \
+    yum update -y && \
+    yum install -y \
+                   devtoolset-2-binutils \
+                   devtoolset-2-gcc \
+                   devtoolset-2-gcc-c++ && \
+    yum clean all
+
+# Download and install tini for zombie reaping.
+RUN curl -s -L -O https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
+    openssl md5 tini | grep 596b898785d2f169ec969445087c14d6 && \
+    chmod +x tini && \
+    mv tini /usr/local/bin
+
+# Install the latest Miniconda with Python 3 and update everything.
+RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
+    export PATH=/opt/conda/bin:$PATH && \
+    conda config --set show_channel_urls True && \
+    conda update --all --yes && \
+    conda clean -tipy
+
+# Install Obvious-CI.
+RUN export PATH="/opt/conda/bin:${PATH}" && \
+    conda install --yes -c pelson/channel/development obvious-ci && \
+    obvci_install_conda_build_tools.py && \
+    conda clean -tipsy
+
+# Install conda-forge git.
+RUN export PATH="/opt/conda/bin:${PATH}" && \
+    conda install --yes -c conda-forge git && \
+    conda clean -tipsy
+
+# udunits2.
+# libtool texinfo
+# RUN yum install -y expat-devel
+
+COPY entrypoint_source /opt/docker/bin/entrypoint_source
+COPY entrypoint /opt/docker/bin/entrypoint
+
+# Ensure that all containers start with tini and the user selected process.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
+ENTRYPOINT [ "/usr/local/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]

--- a/linux-anvil-cudnn/entrypoint
+++ b/linux-anvil-cudnn/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Source everything that needs to be.
+. /opt/docker/bin/entrypoint_source
+
+# Run whatever the user wants.
+exec "$@"

--- a/linux-anvil-cudnn/entrypoint_source
+++ b/linux-anvil-cudnn/entrypoint_source
@@ -1,0 +1,11 @@
+# Enable the compiler toolset.
+#
+# Must do this before activating conda or
+# the system Python interpreter is not used.
+# This is a problem for many reasons. One being
+# that the Python scripts used to activate the
+# toolset are not Python 3 compatible.
+. scl_source enable devtoolset-2
+
+# Activate the `root` conda environment.
+. /opt/conda/bin/activate root


### PR DESCRIPTION
Adds a docker image with CUDA and cuDNN. This is being done for CUDA as it is difficult to redistribute correctly. As far as cuDNN, we are not allowed to redistribute it; however, we are allowed to use their docker image this includes it. More discussion can be seen in this issue ( https://github.com/conda-forge/staged-recipes/issues/654 ). Please share thoughts and feedback on this potential solution.

cc @msarahan @lebedov
