### PR TITLE
WIP: Switch to devtoolset-4

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -28,17 +28,15 @@ RUN yum update -y && \
                    mesa-libGL-devel && \
     yum clean all
 
-# Install devtoolset 2.
+# Install devtoolset 4.
 RUN yum update -y && \
     yum install -y \
                    centos-release-scl \
-                   yum-utils && \
-    yum-config-manager --add-repo http://people.centos.org/tru/devtools-2/devtools-2.repo && \
     yum update -y && \
     yum install -y \
-                   devtoolset-2-binutils \
-                   devtoolset-2-gcc \
-                   devtoolset-2-gcc-c++ && \
+                   devtoolset-4-binutils \
+                   devtoolset-4-gcc \
+                   devtoolset-4-gcc-c++ && \
     yum clean all
 
 # Download and install tini for zombie reaping.

--- a/linux-anvil/entrypoint_source
+++ b/linux-anvil/entrypoint_source
@@ -5,7 +5,7 @@
 # This is a problem for many reasons. One being
 # that the Python scripts used to activate the
 # toolset are not Python 3 compatible.
-. scl_source enable devtoolset-2
+. scl_source enable devtoolset-4
 
 # Activate the `root` conda environment.
 . /opt/conda/bin/activate root


### PR DESCRIPTION
This PR proposes that we switch to devtoolset-4. It is needed to package `libdynd`. The devtoolset provides C++14 support and `gcc` 5.2.1. Just like devtoolset-2, we will still be able to ship to any CentOS 6 machine without needing to include standard system libraries. There is no change to our GLIBC compatibility. In the long run, it sounds like we want to package `gcc`. However, this should hold us over until then.

cc @msarahan @jjhelmus @pelson @ocefpaf @izaid
