### PR TITLE
Add conda-forge channel

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -64,7 +64,7 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
 
 # Install conda-forge git.
 RUN export PATH="/opt/conda/bin:${PATH}" && \
-    conda install --yes -c conda-forge git && \
+    conda install --yes git && \
     conda clean -tipsy
 
 # udunits2.

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x8
 
 # Install Obvious-CI.
 RUN export PATH="/opt/conda/bin:${PATH}" && \
-    conda install --yes -c pelson/channel/development obvious-ci && \
+    conda install --yes obvious-ci && \
     obvci_install_conda_build_tools.py && \
     conda clean -tipsy
 

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -52,6 +52,7 @@ RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x8
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \
+    conda config --add channels conda-forge && \
     conda update --all --yes && \
     conda clean -tipy
 


### PR DESCRIPTION
Currently, we do not add the `conda-forge` channel in the docker image. While this initially made sense given the history of this docker image (as it [precedes]( https://github.com/pelson/Obvious-CI/blob/d82cabc1f80a0151b914d3ebb498043ace169562/obvious-ci.docker/linux64_obvci/Dockerfile ) conda-forge), it has long since migrated to conda-forge and has been upgraded accordingly. While this itself doesn't justify adding the channel, it does show that there should not be any significant blockers to doing so.

That all being said, there are some good reasons for including the `conda-forge` channel at this stage. Right now a sizable amount of time in each CircleCI build is spent updating from `defaults` packages to `conda-forge` packages. This is being done in every CircleCI build no matter what is being built. In some cases, this may be the straw breaking the camel's back ( https://github.com/conda-forge/scipy-feedstock/issues/8 ).

Additionally, adding the `conda-forge` channel is another step that everyone is having to do when trying to debug a build in the docker. While not challenging to do, it is something easily forgotten and thus eats little bits of developer time often. Occasionally it can cause unnecessary confusion.

Both of these problems can be easily solved by simply adding and using the `conda-forge` channel in the Docker build. As a result, we don't need to waste CI time regularly doing these updates. Also, we provide a more user friendly Docker image out-of-the-box. Furthermore, re-adding the channel seems to have no adverse affect. In fact, it appears to be a no-op.

In conclusion, we should add the `conda-forge` channel to the Docker image for a wide variety of benefits.