### PR TITLE
Fix prompt

### DIFF
--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -il
 
 # Source everything that needs to be.
 . /opt/docker/bin/entrypoint_source


### PR DESCRIPTION
Previously the `PS1` prompt was set correctly by `bash` when the container started.

However, now `conda` mucks with `PS1` before `bash` starts in activation. So `bash` won't change the prompt afterwards. Further `conda` deactivation will hang.

This sets the prompt before `conda` activates so that there is a prompt and `conda` deactivation works. This is primarily of value for offline use.

Tested for local use interactively. Also tested building `pycrypto` with the Docker build script using it. Both worked fine.