### PR TITLE
Validate Miniconda download with checksum

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -48,8 +48,10 @@ RUN curl -s -L -O https://github.com/krallin/tini/releases/download/v0.10.0/tini
     mv tini /usr/local/bin
 
 # Install the latest Miniconda with Python 3 and update everything.
-RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
+RUN curl -s -L http://repo.continuum.io/miniconda/Miniconda3-4.1.11-Linux-x86_64.sh > miniconda.sh && \
+    openssl md5 miniconda.sh | grep 874dbb0d3c7ec665adf7231bbb575ab2 && \
+    bash miniconda.sh -b -p /opt/conda && \
+    rm miniconda.sh && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \
     conda config --add channels conda-forge && \


### PR DESCRIPTION
This picks a particular version of Miniconda to install (still the most recent one available) and installs it. Also, it verifies that its checksum matches what we expect it too. Not that we have any reason to think these wouldn't match. Still it is good practice to be using checksums to verify things that we have downloaded.

We need to pick a particular Miniconda version so that we can be sure about the checksum we are getting. If we were downloading latest, the checksum would change when there is a new Miniconda release. This shouldn't be a problem when we download a specific version.

In the future, we will need to explicitly update our Miniconda installs to new versions as needed. However, in practice, we may not need to do this very often as we upgrade everything in the Docker build anyways. Plus, we are switching over to conda-forge packages for nearly everything that would come included.