### PR TITLE
Drop system `gcc` (have devtoolset already)

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -16,7 +16,6 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 RUN yum update -y && \
     yum install -y \
                    bzip2 \
-                   gcc-c++ \
                    make \
                    patch \
                    tar \


### PR DESCRIPTION
This proposes we drop the system `gcc`. As we already include the devtoolset compiler, there is really no need for this other compiler to also be installed. After all the system `gcc` is not even used. Dropping the system `gcc` would result in a ~5% size reduction in the final image. Have tested some simple C and C++ programs to verify this doesn't have any effect.