### PR TITLE
WIP: Install `lsb_release`

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -17,6 +17,7 @@ RUN yum update -y && \
     yum install -y \
                    bzip2 \
                    make \
+                   redhat-lsb-core \
                    patch \
                    tar \
                    which \


### PR DESCRIPTION
Installs `lsb_release` to aid the `conda` packaged `gcc` post link scripts. This is prompted by discussion in gitter from [start](https://gitter.im/conda-forge/conda-forge.github.io?at=57cd87cd780310286bb3ac1a) to [end](https://gitter.im/conda-forge/conda-forge.github.io?at=57cd88d5cdbf820f7f9c5e4e). The origin of this call to `lsb_release` in the `gcc` package comes from PR ( https://github.com/conda/conda-recipes/pull/570 ).

cc @astrofrog @ocefpaf @msarahan @jjhelmus @pelson
