### PR TITLE
WIP: Install minimal `lsb_release`

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -17,6 +17,7 @@ RUN yum update -y && \
     yum install -y \
                    bzip2 \
                    make \
+                   redhat-lsb-core \
                    patch \
                    tar \
                    which \

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -17,7 +17,6 @@ RUN yum update -y && \
     yum install -y \
                    bzip2 \
                    make \
-                   redhat-lsb-core \
                    patch \
                    tar \
                    which \
@@ -25,14 +24,15 @@ RUN yum update -y && \
                    libXrender-devel \
                    libSM-devel \
                    libX11-devel \
-                   mesa-libGL-devel && \
+                   mesa-libGL-devel \
+                   yum-utils && \
+    rpm -Uvh --nodeps $(repoquery --location --archlist=$(arch) redhat-lsb-core) && \
     yum clean all
 
 # Install devtoolset 2.
 RUN yum update -y && \
     yum install -y \
-                   centos-release-scl \
-                   yum-utils && \
+                   centos-release-scl && \
     yum-config-manager --add-repo http://people.centos.org/tru/devtools-2/devtools-2.repo && \
     yum update -y && \
     yum install -y \


### PR DESCRIPTION
Installs `lsb_release` to aid the `conda` packaged `gcc` post link scripts. This is prompted by discussion in gitter from [start](https://gitter.im/conda-forge/conda-forge.github.io?at=57cd87cd780310286bb3ac1a) to [end](https://gitter.im/conda-forge/conda-forge.github.io?at=57cd88d5cdbf820f7f9c5e4e). The origin of this call to `lsb_release` in the `gcc` package comes from PR ( https://github.com/conda/conda-recipes/pull/570 ).

Basically the same as PR ( https://github.com/conda-forge/docker-images/pull/34 ). However, this is the minimal version. It only installs `redhat-lsb-core` and drops all the dependencies intentionally. The `lsb_release` command seems to work fine from testing. So this should still solve the intended problem.

cc @astrofrog @ocefpaf @msarahan @pelson @jjhelmus
