### PR TITLE
Switch to the USNO's time service

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER conda-forge <conda-forge@googlegroups.com>
 ENV LANG en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.
-ADD http://www.timeapi.org/utc/now /opt/docker/etc/timestamp
+ADD http://tycho.usno.navy.mil/timer.html /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6


### PR DESCRIPTION
It appears that timeapi.org has been taken offline and the domain is up for grabs. To still ensure the cache is busted at the beginning of the Docker build, this switches to the USNO's time service to get the time since the last epoch. This should allow us to still bust the cache and save the time when the image was built.