### PR TITLE
Pin tini

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -73,6 +73,8 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
     conda install --yes --quiet conda-build anaconda-client jinja2 setuptools && \
     conda install --yes git && \
     conda install --yes tini && \
+    export CONDA_TINI_INFO=( `conda list tini | grep tini` ) && \
+    echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
     conda clean -tipsy
 
 # Add a file for users to source to activate the `conda`

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -61,6 +61,7 @@ RUN curl -s -L https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_6
     openssl md5 miniconda.sh | grep c1c15d3baba15bf50293ae963abef853 && \
     bash miniconda.sh -b -p /opt/conda && \
     rm miniconda.sh && \
+    touch /opt/conda/conda-meta/pinned && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \
     conda config --add channels conda-forge && \


### PR DESCRIPTION
Make sure `tini` is pinned to the exact version installed with `conda` when building the image. Upgrading `tini` while running the Docker image from the entrypoint may have unexpected effects. So this should hopefully prevent those issues by locking `tini` to a certain version.