### PR TITLE
Ensure that the `conda` user owns home

### DIFF
--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -11,7 +11,8 @@ export LOGNAME=conda
 export MAIL=/var/spool/mail/conda
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 chown -R conda /opt/conda
-cp /root/.condarc $HOME/.condarc && chown conda $HOME/.condarc
+cp /root/.condarc $HOME/.condarc
+chown -R conda $HOME
 
 # Source everything that needs to be.
 . /opt/docker/bin/entrypoint_source


### PR DESCRIPTION
In case the `conda` user's home directory already exists (as happens when something gets mounted to that location), make sure that the home directory still ends up being owned by the `conda` user in the end and all of its contents.