### PR TITLE
Ensure `conda` group owns `/home/conda/.condarc`

### DIFF
--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -11,7 +11,7 @@ export LOGNAME=conda
 export MAIL=/var/spool/mail/conda
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 chown -R conda /opt/conda
-cp /root/.condarc $HOME/.condarc && chown conda $HOME/.condarc
+cp /root/.condarc $HOME/.condarc && chown conda:conda $HOME/.condarc
 
 # Source everything that needs to be.
 . /opt/docker/bin/entrypoint_source


### PR DESCRIPTION
Touch up to PR ( https://github.com/conda-forge/docker-images/pull/36 ).

As we were only using `chown` and not `chown -R` with `/home/conda/.condarc`, the user changed to `conda`, but the group remained `root`. This fixes that issue by forcing the user and group to be changed to `conda` explicitly for `/home/conda/.condarc`.