### PR TITLE
Switch to the `conda` user's home directory

### DIFF
--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -12,6 +12,7 @@ export MAIL=/var/spool/mail/conda
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 chown -R conda /opt/conda
 cp /root/.condarc $HOME/.condarc && chown conda:conda $HOME/.condarc
+cd $HOME
 
 # Source everything that needs to be.
 . /opt/docker/bin/entrypoint_source


### PR DESCRIPTION
Touch up to PR ( https://github.com/conda-forge/docker-images/pull/36 ).

Instead of dropping into `/`, it makes more sense to drop into `/home/conda`. As we use absolute paths throughout, this is largely a cosmetic touch. However it would help if the current working directory is a place that allows us to create things without issues.