### PR TITLE
Fix user creation when user's home directory already exists

### DIFF
--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -10,6 +10,7 @@ export USER=conda
 export LOGNAME=conda
 export MAIL=/var/spool/mail/conda
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
+chown conda:conda $HOME
 chown -R conda:conda /opt/conda
 cp /root/.condarc $HOME/.condarc && chown conda:conda $HOME/.condarc
 cd $HOME

--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -10,7 +10,7 @@ export USER=conda
 export LOGNAME=conda
 export MAIL=/var/spool/mail/conda
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
-chown -R conda /opt/conda
+chown -R conda:conda /opt/conda
 cp /root/.condarc $HOME/.condarc && chown conda:conda $HOME/.condarc
 cd $HOME
 

--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -12,6 +12,7 @@ export MAIL=/var/spool/mail/conda
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 chown conda:conda $HOME
 chown -R conda:conda /opt/conda
+cp -R /etc/skel $HOME && chown -R conda:conda $HOME/skel && (ls -A1 $HOME/skel | xargs -I {} mv -n $HOME/skel/{} $HOME) && rm -Rf $HOME/skel
 cp /root/.condarc $HOME/.condarc && chown conda:conda $HOME/.condarc
 cd $HOME
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/docker-images/pull/36 ).

Fixes a few issues that crop up when `/home/conda` already exists (normally due to the mount location being with `/home/conda`). Namely make sure the `conda` user owns their home directory and includes the files from `/etc/skel`. Also make sure `/opt/conda` belongs to the `conda` group.