### PR TITLE
Use our gosu

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -41,17 +41,6 @@ RUN yum update -y && \
                    devtoolset-2-gcc-c++ && \
     yum clean all
 
-# Install gosu to be used in the entrypoint, reason why to use it instead of
-# su or sudo can be found on the project docs
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" && \
-    openssl sha256 /usr/local/bin/gosu | grep 5b3b03713a888cee84ecbf4582b21ac9fd46c3d935ff2d7ea25dd5055d302d3c && \
-    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" && \
-    openssl sha256 /usr/local/bin/gosu.asc | grep b026f831a268f6c31daec4234547e4bb0228400babad3d6f6561b6626855af44 && \
-    gpg --verify /usr/local/bin/gosu.asc && \
-    rm /usr/local/bin/gosu.asc && \
-    chmod +x /usr/local/bin/gosu
-
 # give sudo permission for conda user to run yum (user creation is postponed
 # to the entrypoint, so we can create a user with the same id as the host)
 RUN echo 'conda ALL=NOPASSWD: /usr/bin/yum' >> /etc/sudoers

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -65,6 +65,9 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
 
 # Install docker tools.
 RUN export PATH="/opt/conda/bin:${PATH}" && \
+    conda install --yes gosu && \
+    export CONDA_GOSU_INFO=( `conda list gosu | grep gosu` ) && \
+    echo "gosu ${CONDA_GOSU_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
     conda install --yes tini && \
     export CONDA_TINI_INFO=( `conda list tini | grep tini` ) && \
     echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned && \

--- a/linux-anvil/entrypoint
+++ b/linux-anvil/entrypoint
@@ -20,4 +20,4 @@ cd $HOME
 . /opt/docker/bin/entrypoint_source
 
 # Run whatever the user wants.
-exec /usr/local/bin/gosu conda "$@"
+exec /opt/conda/bin/gosu conda "$@"


### PR DESCRIPTION
Switches over to our `gosu` package instead of downloading a prebuilt binary. Since it was built in our Docker image, we know it is compatible with CentOS 6. Also as we built this copy of `gosu` ourselves, we are able to more easily include things like the license file.