### PR TITLE
Use new time server to bust cache

### DIFF
--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER conda-forge <conda-forge@googlegroups.com>
 ENV LANG en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.
-ADD http://tycho.usno.navy.mil/timer.html /opt/docker/etc/timestamp
+ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6


### PR DESCRIPTION
Appears that USNO's time server redirects to `https`, but their certificates are invalid for some reason. Probably a consequence of their recent move to `https`. Would expect them to fix this in the future. For now, switch to a new time server to bust the cache. This provides the output in JSON with a few formats as opposed to a simple string, but is otherwise just text. Should work for our needs.