### PR TITLE
Improve debugging in `scripts/run_commands`

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -1,5 +1,7 @@
 #!/bin/bash -il
 
+set -eo pipefail
+
 if [ "$(uname -m)" = "x86_64" ]; then
    export supkg="gosu"
    export condapkg="Miniconda3-4.3.21-Linux-x86_64.sh"

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -17,31 +17,31 @@ fi
 echo 'conda ALL=NOPASSWD: /usr/bin/yum' >> /etc/sudoers
 
 # Install the latest Miniconda with Python 3 and update everything.
-curl -s -L https://repo.continuum.io/miniconda/$condapkg > miniconda.sh && \
-openssl md5 miniconda.sh | grep $conda_chksum && \
-bash miniconda.sh -b -p /opt/conda && \
-rm miniconda.sh && \
-touch /opt/conda/conda-meta/pinned && \
-export PATH=/opt/conda/bin:$PATH && \
-conda config --set show_channel_urls True && \
-conda config --add channels conda-forge && \
-conda update --all --yes && \
+curl -s -L https://repo.continuum.io/miniconda/$condapkg > miniconda.sh
+openssl md5 miniconda.sh | grep $conda_chksum
+bash miniconda.sh -b -p /opt/conda
+rm miniconda.sh
+touch /opt/conda/conda-meta/pinned
+export PATH=/opt/conda/bin:$PATH
+conda config --set show_channel_urls True
+conda config --add channels conda-forge
+conda update --all --yes
 conda clean -tipy
 
 # Install conda build and deployment tools.
-export PATH=/opt/conda/bin:$PATH && \
-conda install --yes --quiet conda-build anaconda-client jinja2 setuptools && \
-conda install --yes git && \
+export PATH=/opt/conda/bin:$PATH
+conda install --yes --quiet conda-build anaconda-client jinja2 setuptools
+conda install --yes git
 conda clean -tipsy
 
 # Install docker tools
-export PATH=/opt/conda/bin:$PATH && \
-conda install --yes $supkg && \
-export CONDA_SUEXEC_INFO=( `conda list $supkg | grep $supkg` ) && \
-echo "$supkg ${CONDA_SUEXEC_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
-conda install --yes tini && \
-export CONDA_TINI_INFO=( `conda list tini | grep tini` ) && \
-echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
+export PATH=/opt/conda/bin:$PATH
+conda install --yes $supkg
+export CONDA_SUEXEC_INFO=( `conda list $supkg | grep $supkg` )
+echo "$supkg ${CONDA_SUEXEC_INFO[1]}" >> /opt/conda/conda-meta/pinned
+conda install --yes tini
+export CONDA_TINI_INFO=( `conda list tini | grep tini` )
+echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned
 conda clean -tipsy
 
 # Lucky group gets permission to write in the conda dir

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -1,6 +1,6 @@
 #!/bin/bash -il
 
-set -eo pipefail
+set -exo pipefail
 
 if [ "$(uname -m)" = "x86_64" ]; then
    export supkg="gosu"

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -22,7 +22,7 @@ openssl md5 miniconda.sh | grep $conda_chksum
 bash miniconda.sh -b -p /opt/conda
 rm miniconda.sh
 touch /opt/conda/conda-meta/pinned
-export PATH=/opt/conda/bin:$PATH
+export PATH="/opt/conda/bin:${PATH}"
 conda config --set show_channel_urls True
 conda config --add channels conda-forge
 conda update --all --yes

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -29,13 +29,11 @@ conda update --all --yes
 conda clean -tipy
 
 # Install conda build and deployment tools.
-export PATH=/opt/conda/bin:$PATH
 conda install --yes --quiet conda-build anaconda-client jinja2 setuptools
 conda install --yes git
 conda clean -tipsy
 
 # Install docker tools
-export PATH=/opt/conda/bin:$PATH
 conda install --yes $supkg
 export CONDA_SUEXEC_INFO=( `conda list $supkg | grep $supkg` )
 echo "$supkg ${CONDA_SUEXEC_INFO[1]}" >> /opt/conda/conda-meta/pinned

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -16,31 +16,31 @@ echo 'conda ALL=NOPASSWD: /usr/bin/yum' >> /etc/sudoers
 
 # Install the latest Miniconda with Python 3 and update everything.
 curl -s -L https://repo.continuum.io/miniconda/$condapkg > miniconda.sh && \
-    openssl md5 miniconda.sh | grep $conda_chksum && \
-    bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh && \
-    touch /opt/conda/conda-meta/pinned && \
-    export PATH=/opt/conda/bin:$PATH && \
-    conda config --set show_channel_urls True && \
-    conda config --add channels conda-forge && \
-    conda update --all --yes && \
-    conda clean -tipy
+openssl md5 miniconda.sh | grep $conda_chksum && \
+bash miniconda.sh -b -p /opt/conda && \
+rm miniconda.sh && \
+touch /opt/conda/conda-meta/pinned && \
+export PATH=/opt/conda/bin:$PATH && \
+conda config --set show_channel_urls True && \
+conda config --add channels conda-forge && \
+conda update --all --yes && \
+conda clean -tipy
 
 # Install conda build and deployment tools.
-export PATH="/opt/conda/bin:${PATH}" && \
-    conda install --yes --quiet conda-build anaconda-client jinja2 setuptools && \
-    conda install --yes git && \
-    conda clean -tipsy
+export PATH=/opt/conda/bin:$PATH && \
+conda install --yes --quiet conda-build anaconda-client jinja2 setuptools && \
+conda install --yes git && \
+conda clean -tipsy
 
 # Install docker tools
-export PATH="/opt/conda/bin:${PATH}" && \
-    conda install --yes $supkg && \
-    export CONDA_SUEXEC_INFO=( `conda list $supkg | grep $supkg` ) && \
-    echo "$supkg ${CONDA_SUEXEC_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
-    conda install --yes tini && \
-    export CONDA_TINI_INFO=( `conda list tini | grep tini` ) && \
-    echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
-    conda clean -tipsy
+export PATH=/opt/conda/bin:$PATH && \
+conda install --yes $supkg && \
+export CONDA_SUEXEC_INFO=( `conda list $supkg | grep $supkg` ) && \
+echo "$supkg ${CONDA_SUEXEC_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
+conda install --yes tini && \
+export CONDA_TINI_INFO=( `conda list tini | grep tini` ) && \
+echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
+conda clean -tipsy
 
 # Lucky group gets permission to write in the conda dir
 groupadd -g 32766 lucky


### PR DESCRIPTION
There are a few holdovers in `scripts/run_commands` from when it used to be part of the `Dockerfile`. As it is now a bash script, these things can be cleaned up and streamlined a bit. Plus we could use a bit more visibility into the script while it runs on CI by echoing commands to make it easier to see when problems show up.