### PR TITLE
Use force when removing `miniconda.sh`

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -20,7 +20,7 @@ echo 'conda ALL=NOPASSWD: /usr/bin/yum' >> /etc/sudoers
 curl -s -L https://repo.continuum.io/miniconda/$condapkg > miniconda.sh
 openssl md5 miniconda.sh | grep $conda_chksum
 bash miniconda.sh -b -p /opt/conda
-rm miniconda.sh
+rm -f miniconda.sh
 touch /opt/conda/conda-meta/pinned
 ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
 source /opt/conda/etc/profile.d/conda.sh


### PR DESCRIPTION
As this is a file downloaded by `root`, the system will ask us to confirm our decision to remove the file. Since we are running in batch, it simply assumes the answer is no and proceeds. As a result, a copy of `miniconda.sh` (weighing in at about 34MB) is getting packaged in our Docker image increasing the image size.

To fix this, start using `rm -f` to forcibly remove `miniconda.sh`. This way when Docker goes to commit this layer, `miniconda.sh` won't be present and so will not be included. Should help improve image size and cutdown on clutter.