### PR TITLE
Drop X11 reqs from new compiler Docker image

### DIFF
--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -19,12 +19,7 @@ RUN yum update -y && \
                    patch \
                    sudo \
                    tar \
-                   which \
-                   libXext-devel \
-                   libXrender-devel \
-                   libSM-devel \
-                   libX11-devel \
-                   mesa-libGL-devel && \
+                   which && \
     yum clean all
 
 # Run common commands


### PR DESCRIPTION
All of these are either conda-forge packages that we should be using and/or are using or there are CDTs we should be using for these. Given this, go ahead and drop these X11 packages from the new compiler Docker image. Admittedly this is a breaking change for some packages, but one that we are already adapting in many places.