### PR TITLE
Fixed missing locale pieces for aarch64 and ppc64le

### DIFF
--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.
 # ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
@@ -13,14 +14,21 @@ ENV LANG en_US.UTF-8
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
+# Fix up issues with locales because the default images have these minimized
+# to the point of not being properly functional
+# See: https://github.com/CentOS/sig-cloud-instance-images/issues/71
+RUN yum update -y && \
+    yum reinstall -y glibc-common
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \
-                   bzip2 \
-                   patch \
-                   sudo \
-                   tar \
-                   which && \
+        bzip2 \
+        patch \
+        sudo \
+        tar \
+        which && \
     yum clean all
 
 # Run common commands

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.
-# ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 ENV LANG en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.
-ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -14,12 +14,12 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \
-                   bzip2 \
-                   make \
-                   patch \
-                   sudo \
-                   tar \
-                   which && \
+        bzip2 \
+        make \
+        patch \
+        sudo \
+        tar \
+        which && \
     yum clean all
 
 # Run common commands

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -9,8 +9,8 @@ ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 ENV LANG en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
-# Add a timestamp for the build. Also, bust the cache.cat /proc/sys/fs/binfmt_misc/ppc64le
-ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
+# Add a timestamp for the build. Also, bust the cache.
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -7,6 +7,7 @@ ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.cat /proc/sys/fs/binfmt_misc/ppc64le
 ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
@@ -14,14 +15,21 @@ ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
+# Fix up issues with locales because the default images have these minimized
+# to the point of not being properly functional
+# See: https://github.com/CentOS/sig-cloud-instance-images/issues/71
+RUN yum update -y && \
+    yum reinstall -y glibc-common
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \
-                   bzip2 \
-                   patch \
-                   sudo \
-                   tar \
-                   which && \
+        bzip2 \
+        patch \
+        sudo \
+        tar \
+        which && \
     yum clean all
 
 # Run common commands

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 ENV LANG en_US.UTF-8
 
 # Add a timestamp for the build. Also, bust the cache.
-ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6


### PR DESCRIPTION
This fixes the issues where much of the locale information is stripped out of the container that we use to build stuff.

This fixes a lot of the _"Failed to set locale, defaulting to C"_ style message that appear during certain builds