### PR TITLE
get compilers from defaults

### DIFF
--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -31,17 +31,17 @@ RUN /opt/docker/bin/run_commands
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate && \
     conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-64 \
-        conda-forge::binutils_linux-64 \
-        conda-forge::gcc_impl_linux-64 \
-        conda-forge::gcc_linux-64 \
-        conda-forge::gfortran_impl_linux-64 \
-        conda-forge::gfortran_linux-64 \
-        conda-forge::gxx_impl_linux-64 \
-        conda-forge::gxx_linux-64 \
-        conda-forge::libgcc-ng \
+        defaults::binutils_impl_linux-64 \
+        defaults::binutils_linux-64 \
+        defaults::gcc_impl_linux-64 \
+        defaults::gcc_linux-64 \
+        defaults::gfortran_impl_linux-64 \
+        defaults::gfortran_linux-64 \
+        defaults::gxx_impl_linux-64 \
+        defaults::gxx_linux-64 \
+        defaults::libgcc-ng \
         defaults::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
+        defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
     conda clean -tsy && \
     chgrp -R lucky /opt/conda && \

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -34,7 +34,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::binutils_impl_linux-64 \
         defaults::binutils_linux-64 \
         defaults::gcc_impl_linux-64 \
-        defaults::gcc_linux-64 \
+        conda-forge::gcc_linux-64 \
         defaults::gfortran_impl_linux-64 \
         defaults::gfortran_linux-64 \
         defaults::gxx_impl_linux-64 \


### PR DESCRIPTION
We should deprecate vendorizing packages from `defaults` to solve channel problems. We should use `strict` instead.

BTW, I'm pinning to `defaults::` here just b/c I'm not sure if we still have some left over compilers in our channel.

Should fix #88.