### PR TITLE
Add CUDA build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,18 @@ matrix:
         - DOCKERIMAGE=linux-anvil-aarch64
         - DOCKERTAG=latest
 
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-cuda
+        - DOCKERTAG=9.2
+        - CUDA_VER=9.2
+
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-cuda
+        - DOCKERTAG=10.0
+        - CUDA_VER=10.0
+
 env:
   global:
     secure: "nM8OaFilQkH14wzD1S6DTGejjo3yL/q/1dpz7144Kw68s8FVqW0zsxCC6960ieokY2LutGSv16qTiIFxnRZnHPCXt7X2MhxcagX8IcMu62DWe2jgqwho0hPI65N/bQYLW1l23e9tjKQxWFZopM4Oyzm6TBqlzibTdbPuQI+YB3RBY0dlkIlupPIYtiNlLRR/HnOyyUny/hg3Z65GWeVpXhiMPqXLlfliTiQ31JgBaNuXiP3/ruSCDeyRPWx62IcPGJ1xVSXL3tvkEI2TpGVCsraKCSbgINhm3AHjQ+8ST6GPMxaOaHrKZzssKJpsZhz1dzWINXTLOQ5LrKtBVwfaevFxDmPEr9RcVlzwAAyuWugCyV4Z6NSt/j2Qqw5qGaiiDHyBH0FMmBgzlPzLZ4JKFsZ68aRkc2qV0MeN0YJRwcQ0EnXRULrcwReBztDHZwixSxqlPpQUwbRr7ne05rBjVoMTKaEhyHPO+KYSwQB1wiQgILBtlP/5ofsYc9Eb46m5JJJhJxuLythKpW9mMqd/US4rQrgEHQ/QRIRYwzGnKf/5WXV3W2o4C9QZpH5Da3J7jOLlqxIY5I+Dv9eEk7XxhT7UaEo7C9tmzjaL2D0yrzPnOnPQhMpmCVNWqdTp1eLcIASKSPbmzz8MuYB5yg48wjXWvDIRBQ6hJyuKHhNGE9k="
@@ -54,7 +66,7 @@ install:
       then
         sed "s|@BASE_IMAGE@|condaforge/${DOCKERIMAGE}|" jnlp-slave/Dockerfile.in > $DOCKERIMAGE/Dockerfile
       fi
-    - docker build -t condaforge/$DOCKERIMAGE:$DOCKERTAG -f $DOCKERIMAGE/Dockerfile --no-cache .
+    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:$DOCKERTAG -f $DOCKERIMAGE/Dockerfile --no-cache .
 
 script:
     - |

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -10,6 +10,9 @@ ENV CUDA_VER ${CUDA_VER}
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 
+# Set path to CUDA install.
+ENV CUDA_HOME /usr/local/cuda
+
 # Add a timestamp for the build. Also, bust the cache.
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -4,6 +4,9 @@ FROM nvidia/cuda:${CUDA_VER}-devel-centos6
 
 LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 
+# Set CUDA_VER during runtime.
+ENV CUDA_VER ${CUDA_VER}
+
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -19,6 +19,9 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
+# Remove preinclude system compilers
+RUN rpm -e --nodeps --verbose gcc gcc-c++
+
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -1,0 +1,60 @@
+FROM centos:6
+
+LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
+
+# Set an encoding to make things work smoothly.
+ENV LANG en_US.UTF-8
+
+# Add a timestamp for the build. Also, bust the cache.
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
+
+# Resolves a nasty NOKEY warning that appears when using yum.
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# Install basic requirements.
+RUN yum update -y && \
+    yum install -y \
+        bzip2 \
+        make \
+        patch \
+        sudo \
+        tar \
+        which && \
+    yum clean all
+
+# Run common commands
+COPY scripts/run_commands /opt/docker/bin/run_commands
+RUN /opt/docker/bin/run_commands
+
+# Download and cache new compiler packages.
+# Should speedup installation of them on CIs.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        defaults::binutils_impl_linux-64 \
+        defaults::binutils_linux-64 \
+        defaults::gcc_impl_linux-64 \
+        defaults::gcc_linux-64 \
+        defaults::gfortran_impl_linux-64 \
+        defaults::gfortran_linux-64 \
+        defaults::gxx_impl_linux-64 \
+        defaults::gxx_linux-64 \
+        defaults::libgcc-ng \
+        defaults::libgfortran-ng \
+        defaults::libstdcxx-ng && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tsy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
+
+# Add a file for users to source to activate the `conda`
+# environment `base`. Also add a file that wraps that for
+# use with the `ENTRYPOINT`.
+COPY linux-anvil-comp7/entrypoint_source /opt/docker/bin/entrypoint_source
+COPY scripts/entrypoint /opt/docker/bin/entrypoint
+
+# Ensure that all containers start with tini and the user selected process.
+# Activate the `conda` environment `base` and the devtoolset compiler.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -1,4 +1,6 @@
-FROM centos:6
+ARG CUDA_VER
+
+FROM nvidia/cuda:${CUDA_VER}-devel-centos6
 
 LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -55,6 +55,17 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 
+# Download and cache CUDA related packages.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        defaults::cudatoolkit=${CUDA_VER} \
+        defaults::cudnn && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tsy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
+
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.

--- a/linux-anvil-cuda/entrypoint_source
+++ b/linux-anvil-cuda/entrypoint_source
@@ -1,0 +1,2 @@
+# Activate the `base` conda environment.
+conda activate base


### PR DESCRIPTION
Have been using this to build some GPU packages for work. Am placing it up here as a draft PR to solicit feedback and start the discussion towards building a community standard. Please share your thoughts.

**Summary:** This creates a Docker image that inherits from the [NVIDIA CUDA Docker images]( https://hub.docker.com/r/nvidia/cuda/ ), which include CUDA and NVCC. This largely borrows from the [`condaforge/linux-anvil-comp7` image]( https://github.com/conda-forge/docker-images/tree/master/linux-anvil-comp7 ) with minor modifications (hopefully clear in the commit history). The goal is to provide a base image for performing Linux GPU builds in.

cc @kkraus14 @mike-wendt @mrocklin @datametrician @msarahan @seibert @jjhelmus @soumith (feel free to include others I may have missed)