### PR TITLE
Drop `make` from Docker images

### DIFF
--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -15,7 +15,6 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 RUN yum update -y && \
     yum install -y \
         bzip2 \
-        make \
         patch \
         sudo \
         tar \

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -26,7 +26,6 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 RUN yum update -y && \
     yum install -y \
         bzip2 \
-        make \
         patch \
         sudo \
         tar \


### PR DESCRIPTION
Fixes https://github.com/conda-forge/docker-images/issues/78

As we are using `make` from `conda-forge` increasingly in recipes when doing a build (partially due to the aarch64/ppc64le migration and partially due to our new best practices), go ahead and drop them from our containers. This will also ensure that recipes add this requirement before going through the aarch64/ppc64le migration, which should help make that migration a bit smoother.

cc @hmaarrfk @conda-forge/core

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->