### PR TITLE
Use `docker build --squash...`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,10 @@ env:
     secure: "nM8OaFilQkH14wzD1S6DTGejjo3yL/q/1dpz7144Kw68s8FVqW0zsxCC6960ieokY2LutGSv16qTiIFxnRZnHPCXt7X2MhxcagX8IcMu62DWe2jgqwho0hPI65N/bQYLW1l23e9tjKQxWFZopM4Oyzm6TBqlzibTdbPuQI+YB3RBY0dlkIlupPIYtiNlLRR/HnOyyUny/hg3Z65GWeVpXhiMPqXLlfliTiQ31JgBaNuXiP3/ruSCDeyRPWx62IcPGJ1xVSXL3tvkEI2TpGVCsraKCSbgINhm3AHjQ+8ST6GPMxaOaHrKZzssKJpsZhz1dzWINXTLOQ5LrKtBVwfaevFxDmPEr9RcVlzwAAyuWugCyV4Z6NSt/j2Qqw5qGaiiDHyBH0FMmBgzlPzLZ4JKFsZ68aRkc2qV0MeN0YJRwcQ0EnXRULrcwReBztDHZwixSxqlPpQUwbRr7ne05rBjVoMTKaEhyHPO+KYSwQB1wiQgILBtlP/5ofsYc9Eb46m5JJJhJxuLythKpW9mMqd/US4rQrgEHQ/QRIRYwzGnKf/5WXV3W2o4C9QZpH5Da3J7jOLlqxIY5I+Dv9eEk7XxhT7UaEo7C9tmzjaL2D0yrzPnOnPQhMpmCVNWqdTp1eLcIASKSPbmzz8MuYB5yg48wjXWvDIRBQ6hJyuKHhNGE9k="
 
 before_install:
+    # Enable experimental features (needed for squash)
+    - sudo cp docker_daemon_config.json /etc/docker/daemon.json
+    - sudo service docker restart
+
     - docker info
     - |
       if [ "$(uname -m)" = "x86_64" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
       then
         sed "s|@BASE_IMAGE@|condaforge/${DOCKERIMAGE}|" jnlp-slave/Dockerfile.in > $DOCKERIMAGE/Dockerfile
       fi
-    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:$DOCKERTAG -f $DOCKERIMAGE/Dockerfile --no-cache .
+    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:$DOCKERTAG -f $DOCKERIMAGE/Dockerfile --no-cache --squash .
 
 script:
     - |

--- a/docker_daemon_config.json
+++ b/docker_daemon_config.json
@@ -1,0 +1,3 @@
+{
+    "experimental": true
+}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/docker-images/issues/82

This enables [Docker's experimental features]( https://github.com/docker/docker-ce/blob/554e31a7e6544d17ef74d5656c0e6d1af590fbd0/components/cli/experimental/README.md#use-docker-experimental ) on Travis CI, which are needed to run `docker build` with [the `--squash` flag]( https://github.com/docker/docker-ce/blob/554e31a7e6544d17ef74d5656c0e6d1af590fbd0/components/cli/docs/reference/commandline/build.md#squash-an-images-layers---squash-experimental ). When using this flag with `docker build`, all layers are squashed together into one layer at the end. This history itself is retained, but none of the previous layers contain anything addition. Though the base image (used in `FROM`) is retained in the history with its original size.

To get a sense of what this would provide, I tried building the `condaforge/linux-anvil-comp7` image. Currently the image size is 2.45GB. After building with `--squash`, the image is 1.74GB. Overall this is a 0.71GB reduction in size or roughly 30%. All just by flipping a switch and adding a flag!

This flag is great because the benefit is immediately extended to all of the images we maintain here. Also it carries forward to whatever changes we make to the images here. Plus we no longer need to feel a need to jam all commands into one `RUN` (unless we like that style for some reason). So all around this a nice win for both image size and maintainability here with very little effort. 😄

cc @epruesse