### PR TITLE
Redeclare `CUDA_VER` build argument

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -5,6 +5,7 @@ FROM nvidia/cuda:${CUDA_VER}-devel-centos6
 LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 
 # Set CUDA_VER during runtime.
+ARG CUDA_VER
 ENV CUDA_VER ${CUDA_VER}
 
 # Set an encoding to make things work smoothly.


### PR DESCRIPTION
It appears that Docker will forget the build argument during the build if it was used in `FROM`. Redeclaring the build argument after `FROM` seems to work. Also this allows us to inject it into an environment variable for easier use later on.

ref: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact