### PR TITLE
Test `condaforge/linux-anvil-comp7` on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     environment:
-      DOCKERIMAGE: linux-anvil
+      DOCKERIMAGE: linux-anvil-comp7
     working_directory: ~/test
     machine: true
     steps:


### PR DESCRIPTION
This image is newer and actively used (unlike `condaforge/linux-anvil`). So switch the CircleCI tests to use this image instead.

xref: https://github.com/conda-forge/docker-images/issues/101