### PR TITLE
 Make subsequent chgrp/chmod more selective (reduce image size)

### DIFF
--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -54,7 +54,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         $_channel::libgfortran-ng \
         $_channel::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     find /opt/conda ! -group lucky -exec chgrp -h lucky {} + -exec chmod u=g {} +
 
 # Add a file for users to source to activate the `conda`

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -26,6 +26,7 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 RUN yum update -y && \
     yum install -y \
         bzip2 \
+        findutils \
         sudo \
         tar \
         which && \
@@ -54,8 +55,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         $_channel::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
     conda clean -tsy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
+    find /opt/conda ! -group lucky -exec chgrp -h lucky {} + -exec chmod u=g {} +
 
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -50,7 +50,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::libgfortran-ng \
         defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     find /opt/conda ! -group lucky -exec chgrp -h lucky {} + -exec chmod u=g {} +
 
 # Add a file for users to source to activate the `conda`

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -23,6 +23,7 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 RUN yum update -y && \
     yum install -y \
         bzip2 \
+        findutils \
         sudo \
         tar \
         which && \
@@ -50,8 +51,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
     conda clean -tsy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
+    find /opt/conda ! -group lucky -exec chgrp -h lucky {} + -exec chmod u=g {} +
 
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -62,7 +62,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::libgfortran-ng \
         defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     find /opt/conda ! -group lucky -exec chgrp -h lucky {} + -exec chmod u=g {} +
 
 # Download and cache CUDA related packages.

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -35,6 +35,7 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 RUN yum update -y && \
     yum install -y \
         bzip2 \
+        findutils \
         sudo \
         tar \
         which && \
@@ -62,8 +63,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
     conda clean -tsy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
+    find /opt/conda ! -group lucky -exec chgrp -h lucky {} + -exec chmod u=g {} +
 
 # Download and cache CUDA related packages.
 RUN source /opt/conda/etc/profile.d/conda.sh && \


### PR DESCRIPTION
Addresses gh-82

Details:
@mbargull in https://github.com/conda-forge/docker-images/pull/99#issuecomment-507417269 :
> Taking a look at https://github.com/conda-forge/docker-images/blob/3bc379c9cbc4c3ae11ed7e4683f9a76cf7d22418/linux-anvil-comp7/Dockerfile#L53-L54 , I'm pretty sure the culprit is in the overzealous `chgrp -R`/`chmod -R`, i.e., those commands change (and thus duplicate in terms of layer contents) already existent files. I'll see if we can do the `chgrp`/`chmod` more selectively.
(I know we don't have to fix that if `--squash` works perfectly as intended (or we use multi-stage builds). But since the change should be minimal, I guess we could fix it anyway, just in case.)