### PR TITLE
 Test for working en_US.UTF-8 locale 

### DIFF
--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -5,6 +5,7 @@ set -xeuo pipefail
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 
 docker info
+docker history "$( docker images -q "condaforge/${DOCKERIMAGE}" )"
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is

--- a/.circleci/test_docker_container.sh
+++ b/.circleci/test_docker_container.sh
@@ -2,6 +2,12 @@
 
 set -xeuo pipefail
 
+# test for working en_US.UTF-8 locale
+locale -a | grep -i 'en_US.UTF.\?8'
+[ "$( LC_ALL=en_US.UTF-8 sh -euc : 2>&1 )" = "" ]
+# make sure the above fails for non-existent locale
+[ ! "$( LC_ALL=badlocale sh -euc : 2>&1 )" = "" ]
+
 # check that /opt/conda has correct permissions
 touch /opt/conda/bin/test_conda_forge
 

--- a/.circleci/test_docker_container.sh
+++ b/.circleci/test_docker_container.sh
@@ -2,11 +2,11 @@
 
 set -xeuo pipefail
 
-# test for working en_US.UTF-8 locale
+echo 'Validating correctly configured en_US.UTF-8 locale...'
 locale -a | grep -i 'en_US.UTF.\?8'
-[ "$( LC_ALL=en_US.UTF-8 sh -euc : 2>&1 )" = "" ]
+[ "$( LC_ALL=en_US.UTF-8 sh -c : 2>&1 )" = "" ]
 # make sure the above fails for non-existent locale
-[ ! "$( LC_ALL=badlocale sh -euc : 2>&1 )" = "" ]
+[ ! "$( LC_ALL=badlocale sh -c : 2>&1 )" = "" ]
 
 # check that /opt/conda has correct permissions
 touch /opt/conda/bin/test_conda_forge

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -50,7 +50,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         $_channel::libgfortran-ng \
         $_channel::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -25,7 +25,8 @@ RUN yum update -y && \
         sudo \
         tar \
         which && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -14,14 +14,6 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
-# Fix up issues with locales because the default images have these minimized
-# to the point of not being properly functional
-# See: https://github.com/CentOS/sig-cloud-instance-images/issues/71
-RUN yum update -y && \
-    yum reinstall -y glibc-common && \
-    yum clean all
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -14,6 +14,9 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
+# (arm64v8/centos:7 only) Fix language override to get a working en_US.UTF-8 locale; backports:
+# https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670
+RUN sed -i 's/override_install_langs=en_US\.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -12,7 +12,8 @@ ENV LANGUAGE=en_US.UTF-8
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64
 
 # (arm64v8/centos:7 only) Fix language override to get a working en_US.UTF-8 locale; backports:
 # https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -19,14 +19,14 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 # https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670
 RUN sed -i 's/override_install_langs=en_US\.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf
 # Install basic requirements.
+COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y && \
     yum install -y \
         bzip2 \
         sudo \
         tar \
         which && \
-    yum clean all && \
-    rm -rf /var/cache/yum/*
+    /opt/docker/bin/yum_clean_all
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -24,7 +24,8 @@ RUN yum update -y && \
         localedef -i en_US -f UTF-8 en_US.UTF-8 && \
         : > /usr/lib/locale/locale-archive.tmpl ; \
     fi && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -18,6 +18,12 @@ RUN yum update -y && \
         sudo \
         tar \
         which && \
+    : '(centos:6 only) If glibc-common is updated, we have to manually purge non-en_US locales.' && \
+    if locale -a | grep nds_DE ; then \
+        mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl && \
+        localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+        : > /usr/lib/locale/locale-archive.tmpl ; \
+    fi && \
     yum clean all
 
 # Run common commands

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -12,20 +12,14 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 # Install basic requirements.
+COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y && \
     yum install -y \
         bzip2 \
         sudo \
         tar \
         which && \
-    : '(centos:6 only) If glibc-common is updated, we have to manually purge non-en_US locales.' && \
-    if locale -a | grep nds_DE ; then \
-        mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl && \
-        localedef -i en_US -f UTF-8 en_US.UTF-8 && \
-        : > /usr/lib/locale/locale-archive.tmpl ; \
-    fi && \
-    yum clean all && \
-    rm -rf /var/cache/yum/*
+    /opt/docker/bin/yum_clean_all
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -48,7 +48,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::libgfortran-ng \
         defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -11,14 +11,6 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
-# Fix up issues with locales because the default images have these minimized
-# to the point of not being properly functional
-# See: https://github.com/CentOS/sig-cloud-instance-images/issues/71
-RUN yum update -y && \
-    yum reinstall -y glibc-common && \
-    yum clean all
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -36,7 +36,8 @@ RUN yum update -y && \
         localedef -i en_US -f UTF-8 en_US.UTF-8 && \
         : > /usr/lib/locale/locale-archive.tmpl ; \
     fi && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -20,14 +20,6 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
-# Fix up issues with locales because the default images have these minimized
-# to the point of not being properly functional
-# See: https://github.com/CentOS/sig-cloud-instance-images/issues/71
-RUN yum update -y && \
-    yum reinstall -y glibc-common && \
-    yum clean all
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -24,20 +24,14 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
 # Install basic requirements.
+COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y && \
     yum install -y \
         bzip2 \
         sudo \
         tar \
         which && \
-    : '(centos:6 only) If glibc-common is updated, we have to manually purge non-en_US locales.' && \
-    if locale -a | grep nds_DE ; then \
-        mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl && \
-        localedef -i en_US -f UTF-8 en_US.UTF-8 && \
-        : > /usr/lib/locale/locale-archive.tmpl ; \
-    fi && \
-    yum clean all && \
-    rm -rf /var/cache/yum/*
+    /opt/docker/bin/yum_clean_all
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -60,7 +60,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::libgfortran-ng \
         defaults::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 
@@ -71,7 +71,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         defaults::cudatoolkit=${CUDA_VER} \
         defaults::cudnn && \
     conda remove --yes --quiet -n test --all && \
-    conda clean -tsy && \
+    conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -30,6 +30,12 @@ RUN yum update -y && \
         sudo \
         tar \
         which && \
+    : '(centos:6 only) If glibc-common is updated, we have to manually purge non-en_US locales.' && \
+    if locale -a | grep nds_DE ; then \
+        mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl && \
+        localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+        : > /usr/lib/locale/locale-archive.tmpl ; \
+    fi && \
     yum clean all
 
 # Run common commands

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -13,7 +13,8 @@ ENV LANGUAGE=en_US.UTF-8
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 
 # Install basic requirements.
 RUN yum update -y && \

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -15,14 +15,6 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
-# Fix up issues with locales because the default images have these minimized
-# to the point of not being properly functional
-# See: https://github.com/CentOS/sig-cloud-instance-images/issues/71
-RUN yum update -y && \
-    yum reinstall -y glibc-common && \
-    yum clean all
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-
 # Install basic requirements.
 RUN yum update -y && \
     yum install -y \

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -17,14 +17,14 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 
 # Install basic requirements.
+COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y && \
     yum install -y \
         bzip2 \
         sudo \
         tar \
         which && \
-    yum clean all && \
-    rm -rf /var/cache/yum/*
+    /opt/docker/bin/yum_clean_all
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -23,7 +23,8 @@ RUN yum update -y && \
         sudo \
         tar \
         which && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -44,7 +44,7 @@ conda clean -tipy
 
 # Install conda build and deployment tools.
 conda install --yes --quiet conda-build anaconda-client jinja2 setuptools git patch python=3.7
-conda clean -tipsy
+conda clean -tipy
 
 # Install docker tools
 conda install --yes $supkg
@@ -54,7 +54,7 @@ echo "$supkg ${CONDA_SUEXEC_INFO[1]}" >> /opt/conda/conda-meta/pinned
 conda install --yes tini
 export CONDA_TINI_INFO=( `conda list tini | grep tini` )
 echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned
-conda clean -tipsy
+conda clean -tipy
 
 # Lucky group gets permission to write in the conda dir
 groupadd -g 32766 lucky

--- a/scripts/yum_clean_all
+++ b/scripts/yum_clean_all
@@ -1,0 +1,12 @@
+#! /bin/sh -eu
+
+# (centos:6 only) If glibc-common is updated, we have to manually purge non-en_US locales.
+if grep -F 'CentOS release 6' /etc/centos-release ; then
+    if locale -a | grep nds_DE ; then
+        cp /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
+        localedef -i en_US -f UTF-8 en_US.UTF-8
+        : > /usr/lib/locale/locale-archive.tmpl
+    fi
+fi
+yum clean all
+rm -rf /var/cache/yum/*


### PR DESCRIPTION
Do we really need the changes from gh-83 and gh-97?
It seems like https://github.com/CentOS/sig-cloud-instance-images/issues/71 is a resolved issue and the locale is working, isn't it?
I'd rather like us to test whether the locale is working and only apply fixes if it really is not.
I couldn't find a reference to a recent issue in gh-83. @mariusvniekerk, @hmaarrfk, can you point me to failing cases such that we can incorporate them in the tests?

Also, @mariusvniekerk, gh-83 has been for `aarch64` only. The only significant difference to `ppc64le` I could find is that `aarch64` does not have https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670#diff-574fa022ad7d0be565da139e942a15cbR92 , i.e., it has `override_install_langs=en_US.UTF-8` in `/etc/yum.conf` instead of `en_US.utf8`. If that is the culprit, we should change that (and upstream it, of course).