### PR TITLE
Use qemu 3.1.0-3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,9 @@ before_install:
       if [ "$(uname -m)" = "x86_64" ]; then
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
       fi
-      export QEMU_STATIC_VERSION=v4.0.0-5
-      qemu_ppc64le_sha256=8a62c08b1bf8f65abc9c34bd8d7d31015f16e27c2d78b62367e7b01d5436005b
-      qemu_aarch64_sha256=010b188f02b3b0269ee1618840b058ff05c6bace18421f7db16bee2c8a4a5d13
+      export QEMU_STATIC_VERSION=v3.1.0-3
+      qemu_ppc64le_sha256=d018b96e20f7aefbc50e6ba93b6cabfd53490cdf1c88b02e7d66716fa09a7a17
+      qemu_aarch64_sha256=a64b39b8ce16e2285cb130bcba7143e6ad2fe19935401f01c38325febe64104b
       wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-ppc64le-static
       wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-aarch64-static
       sha256sum qemu-ppc64le-static | grep -F "${qemu_ppc64le_sha256}"


### PR DESCRIPTION
@mariusvniekerk in https://github.com/conda-forge/conda-build-feedstock/pull/101#issuecomment-510133675 :
> I'm not entirely sure what the build errors are on the emulated platforms. It suggests that there may be some issues with how qemu operates since we moved to 4.0.0-5 Should we roll that back to the last good 3.x release?

@mbargull in https://github.com/conda-forge/conda-build-feedstock/pull/101#issuecomment-510181473 :
> Looks like @mariusvniekerk is spot-on:
> ```sh
> >>> docker run --rm -it --entrypoint='' mbargull/condaforge-linux-anvil-aarch64:qemu-3.1.0-3 /opt/conda> /bin/python -c 'import os;os.listxattr(".");print("all good")'
> all good
> >>> docker run --rm -it --entrypoint='' mbargull/condaforge-linux-anvil-aarch64:qemu-4.0.0-5 /opt/conda> /bin/python -c 'import os;os.listxattr(".");print("all good")'
> Traceback (most recent call last):
>   File "<string>", line 1, in <module>
> OSError: [Errno 38] Function not implemented: '.'
> ```

(cc @jjhelmus)