### PR TITLE
Add an armv7l container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
 
     - os: linux
       env:
+        - DOCKERIMAGE=linux-anvil-armv7l
+        - DOCKERTAG=latest
+
+    - os: linux
+      env:
         - DOCKERIMAGE=linux-anvil-cuda
         - DOCKERTAG=9.2
         - CUDA_VER=9.2
@@ -51,12 +56,16 @@ before_install:
       export QEMU_STATIC_VERSION=v3.1.0-3
       qemu_ppc64le_sha256=d018b96e20f7aefbc50e6ba93b6cabfd53490cdf1c88b02e7d66716fa09a7a17
       qemu_aarch64_sha256=a64b39b8ce16e2285cb130bcba7143e6ad2fe19935401f01c38325febe64104b
+      qemu_arm_sha256=f4184c927f78d23d199056c5b0b6d75855e298410571d65582face3159117901
       wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-ppc64le-static
       wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-aarch64-static
+      wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-arm-static
       sha256sum qemu-ppc64le-static | grep -F "${qemu_ppc64le_sha256}"
       sha256sum qemu-aarch64-static | grep -F "${qemu_aarch64_sha256}"
+      sha256sum qemu-arm-static | grep -F "${qemu_aarch64_sha256}"
       chmod +x qemu-ppc64le-static
       chmod +x qemu-aarch64-static
+      chmod +x qemu-arm-static
 
 install:
     - |

--- a/linux-anvil-armv7l/Dockerfile
+++ b/linux-anvil-armv7l/Dockerfile
@@ -1,0 +1,72 @@
+FROM arm32v7/centos:7
+
+ADD qemu-arm-static /usr/bin/qemu-arm-static
+
+LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
+
+# Set an encoding to make things work smoothly.
+ENV LANG en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+# Add a timestamp for the build. Also, bust the cache.
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
+
+# configure yum and rpm for running on non-armv7l architectures
+RUN echo "armhfp" > /etc/yum/vars/basearch && \
+    echo "armv7hl" > /etc/yum/vars/arch && \
+    echo "armv7hl-redhat-linux-gpu" > /etc/rpm/platform
+
+# Resolves a nasty NOKEY warning that appears when using yum.
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
+
+# (arm64v8/centos:7 only) Fix language override to get a working en_US.UTF-8 locale; backports:
+# https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670
+RUN sed -i 's/override_install_langs=en_US\.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf
+# Install basic requirements.
+COPY scripts/yum_clean_all /opt/docker/bin/
+RUN yum update -y && \
+    yum install -y \
+        bzip2 \
+        sudo \
+        tar \
+        which && \
+    /opt/docker/bin/yum_clean_all
+
+# Run common commands
+COPY scripts/run_commands /opt/docker/bin/run_commands
+RUN /opt/docker/bin/run_commands
+
+# Download and cache new compiler packages.
+# Should speedup installation of them on CIs.
+ENV _channel="c4armv7l"
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        $_channel::binutils_impl_linux-armv7l \
+        $_channel::binutils_linux-armv7l \
+        $_channel::gcc_impl_linux-armv7l \
+        $_channel::gcc_linux-armv7l \
+        $_channel::gfortran_impl_linux-armv7l \
+        $_channel::gfortran_linux-armv7l \
+        $_channel::gxx_impl_linux-armv7l \
+        $_channel::gxx_linux-armv7l \
+        $_channel::libgcc-ng \
+        $_channel::libgfortran-ng \
+        $_channel::libstdcxx-ng && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tiy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
+
+# Add a file for users to source to activate the `conda`
+# environment `base`. Also add a file that wraps that for
+# use with the `ENTRYPOINT`.
+COPY linux-anvil-armv7l/entrypoint_source /opt/docker/bin/entrypoint_source
+COPY scripts/entrypoint /opt/docker/bin/entrypoint
+
+# Ensure that all containers start with tini and the user selected process.
+# Activate the `conda` environment `base` and the devtoolset compiler.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]

--- a/linux-anvil-armv7l/Dockerfile
+++ b/linux-anvil-armv7l/Dockerfile
@@ -14,7 +14,7 @@ ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 # configure yum and rpm for running on non-armv7l architectures
 RUN echo "armhfp" > /etc/yum/vars/basearch && \
     echo "armv7hl" > /etc/yum/vars/arch && \
-    echo "armv7hl-redhat-linux-gpu" > /etc/rpm/platform
+    echo "armv7hl-redhat-linux-gnu" > /etc/rpm/platform
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \

--- a/linux-anvil-armv7l/entrypoint_source
+++ b/linux-anvil-armv7l/entrypoint_source
@@ -1,0 +1,2 @@
+# Activate the `base` conda environment.
+conda activate base

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -18,6 +18,12 @@ elif [ "$(uname -m)" = "aarch64" ]; then
    export conda_chksum="7f6f3c6ac5895188766218f222feb131"
    # defaults is not enough
    export additional_channel="--add channels c4aarch64"
+elif [ "$(uname -m)" = "armv7l" ]; then
+   export supkg="su-exec"
+   export condapkg="https://github.com/jjhelmus/conda4armv7l/releases/download/1.0.0/conda4armv7l_installer-1.0.0-Linux-armv7l.sh"
+   export conda_chksum="7d1b7b10d5194d8572cc39dd22fe6e18"
+   # defaults is not enough
+   export additional_channel="--add channels c4armv7l"
 else
    exit 1
 fi


### PR DESCRIPTION
Add a Docker container for building linux-armv7l conda package.  Similar to `aarch64` the initial set of packages come from the `c4armv7l` channel on Anaconda.org which were build from the https://github.com/jjhelmus/conda4armv7l/ repository.