### PR TITLE
Add Docker image for ppc64le and CUDA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,30 @@ matrix:
         - DOCKERIMAGE=miniforge3
         - DOCKERTAG=latest
 
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-ppc64le-cuda
+        - DOCKERTAG=9.2
+        - CUDA_VER=9.2
+
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-ppc64le-cuda
+        - DOCKERTAG=10.0
+        - CUDA_VER=10.0
+
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-ppc64le-cuda
+        - DOCKERTAG=10.1
+        - CUDA_VER=10.1
+
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-ppc64le-cuda
+        - DOCKERTAG=10.2
+        - CUDA_VER=10.2
+
 env:
   global:
     secure: "nM8OaFilQkH14wzD1S6DTGejjo3yL/q/1dpz7144Kw68s8FVqW0zsxCC6960ieokY2LutGSv16qTiIFxnRZnHPCXt7X2MhxcagX8IcMu62DWe2jgqwho0hPI65N/bQYLW1l23e9tjKQxWFZopM4Oyzm6TBqlzibTdbPuQI+YB3RBY0dlkIlupPIYtiNlLRR/HnOyyUny/hg3Z65GWeVpXhiMPqXLlfliTiQ31JgBaNuXiP3/ruSCDeyRPWx62IcPGJ1xVSXL3tvkEI2TpGVCsraKCSbgINhm3AHjQ+8ST6GPMxaOaHrKZzssKJpsZhz1dzWINXTLOQ5LrKtBVwfaevFxDmPEr9RcVlzwAAyuWugCyV4Z6NSt/j2Qqw5qGaiiDHyBH0FMmBgzlPzLZ4JKFsZ68aRkc2qV0MeN0YJRwcQ0EnXRULrcwReBztDHZwixSxqlPpQUwbRr7ne05rBjVoMTKaEhyHPO+KYSwQB1wiQgILBtlP/5ofsYc9Eb46m5JJJhJxuLythKpW9mMqd/US4rQrgEHQ/QRIRYwzGnKf/5WXV3W2o4C9QZpH5Da3J7jOLlqxIY5I+Dv9eEk7XxhT7UaEo7C9tmzjaL2D0yrzPnOnPQhMpmCVNWqdTp1eLcIASKSPbmzz8MuYB5yg48wjXWvDIRBQ6hJyuKHhNGE9k="

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -57,6 +57,17 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
+    
+# Download and cache CUDA related packages.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        defaults::cudatoolkit=${CUDA_VER} \
+        && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tiy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
 
 # Symlink CUDA headers that were moved from $CUDA_HOME/include to /usr/include
 # in CUDA 10.1.

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -57,7 +57,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
-    
+
 # Download and cache CUDA related packages.
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate && \

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -58,17 +58,6 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 
-# Download and cache CUDA related packages.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        defaults::cudatoolkit=${CUDA_VER} \
-        && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Symlink CUDA headers that were moved from $CUDA_HOME/include to /usr/include
 # in CUDA 10.1.
 RUN for HEADER_FILE in cublas_api.h cublas.h cublasLt.h cublas_v2.h cublasXt.h nvblas.h; do \

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -1,0 +1,43 @@
+FROM ppc64le/centos:7
+
+MAINTAINER conda-forge <conda-forge@googlegroups.com>
+
+# Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
+ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
+
+# Set an encoding to make things work smoothly.
+ENV LANG en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+# Add a timestamp for the build. Also, bust the cache.
+ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
+
+# Resolves a nasty NOKEY warning that appears when using yum.
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
+
+# Install basic requirements.
+COPY scripts/yum_clean_all /opt/docker/bin/
+RUN yum update -y && \
+    yum install -y \
+        bzip2 \
+        sudo \
+        tar \
+        which && \
+    /opt/docker/bin/yum_clean_all
+
+# Run common commands
+COPY scripts/run_commands /opt/docker/bin/run_commands
+RUN /opt/docker/bin/run_commands
+
+# Add a file for users to source to activate the `conda`
+# environment `root`. Also add a file that wraps that for
+# use with the `ENTRYPOINT`.
+COPY linux-anvil-ppc64le/entrypoint_source /opt/docker/bin/entrypoint_source
+COPY scripts/entrypoint /opt/docker/bin/entrypoint
+
+# Ensure that all containers start with tini and the user selected process.
+# Activate the `conda` environment `root`.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -1,3 +1,7 @@
+# Note that this image doesn't cache cudatoolkit as it is not packaged by defaults.
+# This docker image is meant for packages using CUDA driver and not for packages
+# using the CUDA runtime.
+
 ARG CUDA_VER
 
 FROM nvidia/cuda-ppc64le:${CUDA_VER}-devel-centos7

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -1,6 +1,12 @@
-FROM ppc64le/centos:7
+ARG CUDA_VER
 
-MAINTAINER conda-forge <conda-forge@googlegroups.com>
+FROM nvidia/cuda-ppc64le:${CUDA_VER}-devel-centos7
+
+LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
+
+# Set CUDA_VER during runtime.
+ARG CUDA_VER
+ENV CUDA_VER ${CUDA_VER}
 
 # Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
@@ -9,12 +15,18 @@ ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 ENV LANG en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
+# Set path to CUDA install.
+ENV CUDA_HOME /usr/local/cuda
+
 # Add a timestamp for the build. Also, bust the cache.
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
 # Resolves a nasty NOKEY warning that appears when using yum.
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
+
+# Remove preinclude system compilers
+RUN rpm -e --nodeps --verbose gcc gcc-c++
 
 # Install basic requirements.
 COPY scripts/yum_clean_all /opt/docker/bin/
@@ -29,6 +41,38 @@ RUN yum update -y && \
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
+
+# Download and cache new compiler packages.
+# Should speedup installation of them on CIs.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        defaults::binutils_impl_linux-ppc64le \
+        defaults::binutils_linux-ppc64le \
+        defaults::gcc_impl_linux-ppc64le \
+        defaults::gcc_linux-ppc64le \
+        defaults::gfortran_impl_linux-ppc64le \
+        defaults::gfortran_linux-ppc64le \
+        defaults::gxx_impl_linux-ppc64le \
+        defaults::gxx_linux-ppc64le \
+        defaults::libgcc-ng \
+        defaults::libgfortran-ng \
+        defaults::libstdcxx-ng && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tiy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
+
+# Download and cache CUDA related packages.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        defaults::cudatoolkit=${CUDA_VER} \
+        defaults::cudnn && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tiy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
 
 # Add a file for users to source to activate the `conda`
 # environment `root`. Also add a file that wraps that for

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -47,28 +47,17 @@ RUN /opt/docker/bin/run_commands
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate && \
     conda create -n test --yes --quiet --download-only \
-        defaults::binutils_impl_linux-ppc64le \
-        defaults::binutils_linux-ppc64le \
-        defaults::gcc_impl_linux-ppc64le \
-        defaults::gcc_linux-ppc64le \
-        defaults::gfortran_impl_linux-ppc64le \
-        defaults::gfortran_linux-ppc64le \
-        defaults::gxx_impl_linux-ppc64le \
-        defaults::gxx_linux-ppc64le \
-        defaults::libgcc-ng \
-        defaults::libgfortran-ng \
-        defaults::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
-# Download and cache CUDA related packages.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        defaults::cudatoolkit=${CUDA_VER} \
-        defaults::cudnn && \
+        conda-forge::binutils_impl_linux-ppc64le \
+        conda-forge::binutils_linux-ppc64le \
+        conda-forge::gcc_impl_linux-ppc64le \
+        conda-forge::gcc_linux-ppc64le \
+        conda-forge::gfortran_impl_linux-ppc64le \
+        conda-forge::gfortran_linux-ppc64le \
+        conda-forge::gxx_impl_linux-ppc64le \
+        conda-forge::gxx_linux-ppc64le \
+        conda-forge::libgcc-ng \
+        conda-forge::libgfortran-ng \
+        conda-forge::libstdcxx-ng && \
     conda remove --yes --quiet -n test --all && \
     conda clean -tiy && \
     chgrp -R lucky /opt/conda && \

--- a/linux-anvil-ppc64le-cuda/entrypoint_source
+++ b/linux-anvil-ppc64le-cuda/entrypoint_source
@@ -1,0 +1,2 @@
+# Activate the `base` conda environment.
+conda activate base


### PR DESCRIPTION
This adds a Docker image that is an amalgamation of the CUDA Docker image and the ppc64le images to enable building ppc64le packages that have CUDA portions enabled as well.

cc @jayfurmanek

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->