### PR TITLE
Use the CUDA image's `entrypoint_source`

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -72,7 +72,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.
-COPY linux-anvil-comp7/entrypoint_source /opt/docker/bin/entrypoint_source
+COPY linux-anvil-cuda/entrypoint_source /opt/docker/bin/entrypoint_source
 COPY scripts/entrypoint /opt/docker/bin/entrypoint
 
 # Ensure that all containers start with tini and the user selected process.


### PR DESCRIPTION
Previously we were pulling the `entrypoint_source` from the `linux-anvil-comp7` directory. However we should have been pulling this from the `linux-anvil-cuda` directory. Hence we fix it accordingly in this PR.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
