### PR TITLE
Add `CUDA_HOME` to the `PATH`

### DIFF
--- a/linux-anvil-cuda/entrypoint_source
+++ b/linux-anvil-cuda/entrypoint_source
@@ -1,2 +1,5 @@
+# Add `CUDA_HOME` binaries to `PATH`.
+export PATH="${PATH}:${CUDA_HOME}/bin"
+
 # Activate the `base` conda environment.
 conda activate base


### PR DESCRIPTION
To ensure that the CUDA binaries are on the `PATH`, add them to the `PATH`. As we [overwrite the `PATH`]( https://github.com/conda-forge/docker-images/blob/6152d61e4afdc63816b4865a72bf17fbb9ced17c/scripts/entrypoint#L14 ) before this point, we cannot add the binaries to the `PATH` earlier (like in the Docker image) as they will be overwritten. In fact the NVIDIA image already adds the binaries to the `PATH`, but we already don't find them due to this overwriting. So add the CUDA binaries in the `entrypoint_source` script. This should ensure they are visible to the user and `conda-build` after starting up the container.