### PR TITLE
Install and use conda-forge's bash

### DIFF
--- a/jnlp-slave/Dockerfile.in
+++ b/jnlp-slave/Dockerfile.in
@@ -3,7 +3,7 @@ FROM @BASE_IMAGE@
 #
 # Fix a few things for Conda
 RUN { \
-      echo '#!/bin/bash'; \
+      echo '#!/opt/conda/bin/bash'; \
       echo 'set -ex'; \
       echo 'cp /root/.condarc /opt/conda'; \
       echo 'source /etc/profile.d/conda.sh';  \

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -64,4 +64,4 @@ COPY scripts/entrypoint /opt/docker/bin/entrypoint
 # Activate the `conda` environment `base` and the devtoolset compiler.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
-CMD [ "/bin/bash" ]
+CMD [ "/opt/conda/bin/bash" ]

--- a/linux-anvil-armv7l/Dockerfile
+++ b/linux-anvil-armv7l/Dockerfile
@@ -69,4 +69,4 @@ COPY scripts/entrypoint /opt/docker/bin/entrypoint
 # Activate the `conda` environment `base` and the devtoolset compiler.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
-CMD [ "/bin/bash" ]
+CMD [ "/opt/conda/bin/bash" ]

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -56,4 +56,4 @@ COPY scripts/entrypoint /opt/docker/bin/entrypoint
 # Activate the `conda` environment `base` and the devtoolset compiler.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
-CMD [ "/bin/bash" ]
+CMD [ "/opt/conda/bin/bash" ]

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -79,4 +79,4 @@ COPY scripts/entrypoint /opt/docker/bin/entrypoint
 # Activate the `conda` environment `base` and the devtoolset compiler.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
-CMD [ "/bin/bash" ]
+CMD [ "/opt/conda/bin/bash" ]

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -40,4 +40,4 @@ COPY scripts/entrypoint /opt/docker/bin/entrypoint
 # Activate the `conda` environment `root`.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
-CMD [ "/bin/bash" ]
+CMD [ "/opt/conda/bin/bash" ]

--- a/scripts/entrypoint
+++ b/scripts/entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash -il
+#!/opt/conda/bin/bash -il
 
 # Use non-interactive cp
 unalias cp
@@ -6,7 +6,7 @@ unalias cp
 # to mounted volumes
 # Adapted from https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
 USER_ID=${HOST_USER_ID:-9001}
-useradd --shell /bin/bash -u $USER_ID -G lucky -o -c "" -m conda
+useradd --shell /opt/conda/bin/bash -u $USER_ID -G lucky -o -c "" -m conda
 export HOME=/home/conda
 export USER=conda
 export LOGNAME=conda

--- a/scripts/jenkins-slave
+++ b/scripts/jenkins-slave
@@ -1,4 +1,4 @@
-#!/bin/bash -il
+#!/opt/conda/bin/bash -il
 
 # The MIT License
 #

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -1,4 +1,4 @@
-#!/bin/bash -il
+#!/bin/sh -il
 
 set -exo pipefail
 
@@ -36,7 +36,7 @@ echo 'conda ALL=NOPASSWD: /usr/bin/yum' >> /etc/sudoers
 curl -s -L $condapkg > miniconda.sh
 md5sum miniconda.sh | grep $conda_chksum
 
-bash miniconda.sh -b -p /opt/conda
+sh miniconda.sh -b -p /opt/conda
 rm -f miniconda.sh
 touch /opt/conda/conda-meta/pinned
 ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -50,7 +50,7 @@ conda clean -tipy
 
 # Install conda build and deployment tools.
 conda install --yes --quiet \
-    git patch \
+    bash git patch \
     python=3.7 setuptools conda-build anaconda-client
 conda clean -tipy
 

--- a/scripts/setup_jenkins
+++ b/scripts/setup_jenkins
@@ -11,7 +11,7 @@ chmod 755 /usr/share/jenkins
 chmod 644 /usr/share/jenkins/slave.jar
 
 groupadd -g ${gid} ${group}
-useradd --shell /bin/bash -c 'Jenkins user' -G lucky -u ${uid} -g ${gid} -m ${user}
+useradd --shell /opt/conda/bin/bash -c 'Jenkins user' -G lucky -u ${uid} -g ${gid} -m ${user}
 
 mkdir /home/${user}/.jenkins
 mkdir /home/${user}/agent


### PR DESCRIPTION
Changes the Docker images to install and use conda-forge's `bash`. This becomes important for images that don't ship `bash` by default.