### PR TITLE
Added cuda-ppc64le image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,12 @@ matrix:
         - DOCKERTAG=10.1
         - CUDA_VER=10.1
 
+    - os: linux
+      env:
+        - DOCKERIMAGE=linux-anvil-cuda-ppc64le
+        - DOCKERTAG=10.1
+        - CUDA_VER=10.1
+
 env:
   global:
     secure: "nM8OaFilQkH14wzD1S6DTGejjo3yL/q/1dpz7144Kw68s8FVqW0zsxCC6960ieokY2LutGSv16qTiIFxnRZnHPCXt7X2MhxcagX8IcMu62DWe2jgqwho0hPI65N/bQYLW1l23e9tjKQxWFZopM4Oyzm6TBqlzibTdbPuQI+YB3RBY0dlkIlupPIYtiNlLRR/HnOyyUny/hg3Z65GWeVpXhiMPqXLlfliTiQ31JgBaNuXiP3/ruSCDeyRPWx62IcPGJ1xVSXL3tvkEI2TpGVCsraKCSbgINhm3AHjQ+8ST6GPMxaOaHrKZzssKJpsZhz1dzWINXTLOQ5LrKtBVwfaevFxDmPEr9RcVlzwAAyuWugCyV4Z6NSt/j2Qqw5qGaiiDHyBH0FMmBgzlPzLZ4JKFsZ68aRkc2qV0MeN0YJRwcQ0EnXRULrcwReBztDHZwixSxqlPpQUwbRr7ne05rBjVoMTKaEhyHPO+KYSwQB1wiQgILBtlP/5ofsYc9Eb46m5JJJhJxuLythKpW9mMqd/US4rQrgEHQ/QRIRYwzGnKf/5WXV3W2o4C9QZpH5Da3J7jOLlqxIY5I+Dv9eEk7XxhT7UaEo7C9tmzjaL2D0yrzPnOnPQhMpmCVNWqdTp1eLcIASKSPbmzz8MuYB5yg48wjXWvDIRBQ6hJyuKHhNGE9k="

--- a/linux-anvil-cuda-ppc64le/Dockerfile
+++ b/linux-anvil-cuda-ppc64le/Dockerfile
@@ -1,0 +1,16 @@
+FROM condaforge/linux-anvil-ppc64le
+
+# Download and cache cuda packages.
+# Should speedup installation of them on CIs.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --download-only \
+        -c https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda cudatoolkit cudatoolkit-dev cudnn && \
+    conda remove --yes -n test --all && \
+    conda clean -tiy
+
+# Ensure that all containers start with tini and the user selected process.
+# Activate the `conda` environment `root`.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This image is based on existing condaforge/linux-anvil-ppc64le image + 3 cuda v10.1 packages:
- cudatoolkit
- cudatoolkit-dev
- cudnn
from https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda channel.