### PR TITLE
Drop explicit `setuptools` install

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -49,7 +49,7 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
-    python=3.7 setuptools conda-build anaconda-client
+    python=3.7 conda-build anaconda-client
 conda clean -tipy
 
 # Install docker tools


### PR DESCRIPTION
Fixes https://github.com/conda-forge/docker-images/issues/112

As `conda-build` already requires `setuptools` and has for a while (since 25 July 2019), go ahead and drop this from being explicitly listed in the `conda install` line here as it will be pulled in anyways.