### PR TITLE
Add step to symlink CUDA headers moved in CUDA 10.1.

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -69,6 +69,14 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 
+# Symlink CUDA headers that were moved from $CUDA_HOME/include to /usr/include
+# in CUDA 10.1.
+RUN for HEADER_FILE in cublas_api.h cublas.h cublasLt.h cublas_v2.h cublasXt.h nvblas.h; do \
+    if [[ ! -f "${CUDA_HOME}/include/${HEADER_FILE}" ]]; \
+    then ln -s "/usr/include/${HEADER_FILE}" "${CUDA_HOME}/include/${HEADER_FILE}"; \
+    fi; \
+    done
+
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This PR adds symlinks to CUBLAS headers in `$CUDA_HOME/include` for CUDA >=10.1.

I had an error with `#include "cublas_v2.h"` for builds of CUDA 10.1 and 10.2, but 9.2 and 10.0 work fine. The paths for CUBLAS changed in 10.1 ([described here](https://forums.developer.nvidia.com/t/cublas-for-10-1-is-missing/71015/2)). 

Some feedstocks have used workarounds for this, like cupy: https://github.com/conda-forge/cupy-feedstock/blob/04418f960647c9f04ffe30c45b716711474a08bb/recipe/meta.yaml#L30-L35

I was not able to build this PR locally. I got this error:
```
Step 11/22 : COPY scripts/yum_clean_all /opt/docker/bin
COPY failed: stat /var/lib/docker/tmp/docker-builder729234824/scripts/yum_clean_all: no such file or directory
```