### PR TITLE
fix missing libcuda.so on 9.2; adapt LD_LIBRARY_PATH

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -11,8 +11,15 @@ ENV CUDA_VER ${CUDA_VER}
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 
-# Set path to CUDA install.
+# Set path to CUDA install (this is a symlink to /usr/local/cuda-${CUDA_VER})
 ENV CUDA_HOME /usr/local/cuda
+# the upstream images for 10.x all have libcuda.so under $CUDA_HOME/compat-$CUDA_VER;
+# add this to the ldconfig so it will be found correctly. For 9.2, the image
+# nvidia/cuda:9.2-devel-centos6 contains neither $CUDA_HOME/compat-$CUDA_VER,
+# nor any (non-stub) libcuda.so. For licensing reasons, these cannot be part of
+# the conda-forge docker images, but are instead added for CI purposes in:
+# github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/run_conda_forge_build_setup_linux
+RUN echo "$CUDA_HOME/compat-$CUDA_VER" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf
 
 # Add a timestamp for the build. Also, bust the cache.
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -19,7 +19,8 @@ ENV CUDA_HOME /usr/local/cuda
 # nor any (non-stub) libcuda.so. For licensing reasons, these cannot be part of
 # the conda-forge docker images, but are instead added for CI purposes in:
 # github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/run_conda_forge_build_setup_linux
-RUN echo "$CUDA_HOME/compat-$CUDA_VER" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf
+RUN echo "$CUDA_HOME/compat-$CUDA_VER" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf && \
+    ldconfig
 
 # Add a timestamp for the build. Also, bust the cache.
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp


### PR DESCRIPTION
Following [discussion](https://github.com/conda-forge/pyarrow-feedstock/pull/101#discussion_r416907727) in https://github.com/conda-forge/pyarrow-feedstock/pull/101, this is a best effort to fix things - I don't claim to understand the subject in depth, just trying to hack things together.

First off, I didn't want to use a `.deb` on centos, so I went with the `.rpm`'s from [upstream](https://developer.download.nvidia.com/compute/cuda/repos/rhel6/x86_64/). Playing around in a `nvidia/cuda:9.2-devel-centos6` container, there's only a stub library:
```
[root@f2a51f1cbd4e /]# find /usr/ -name 'libcuda.so*'
/usr/local/cuda-9.2/targets/x86_64-linux/lib/stubs/libcuda.so
[root@56ddd2cd52b0 /]# ls -la /usr/local/cuda-9.2/targets/x86_64-linux/lib/stubs/libcuda.so
-rwxr-xr-x 1 root root 43192 Jun 13  2018 /usr/local/cuda-9.2/targets/x86_64-linux/lib/stubs/libcuda.so
```

Furthermore, digging through the various rpms when trying to `yum install cuda-runtime-9-2.x86_64`, the actual `libcuda.so` gets installed through `xorg-x11-drv-nvidia-libs`, which pulls in a lot of dependencies (and actually breaks my container, presumably because there's no GPU on my VM?).

Like @pearu in the pyarrow PR, I'm (ab)using `cuda-compat-10.0`, but I'm not too worried about the version mismatch, as the corresponding driver version is even older than what a vanilla `yum install cuda-9-2.x86_64` would pull in (`libcuda.so.410.129` vs `libcuda.so.440.64`).

With this PR, all cuda-versions should now consistently have a `libcuda.so` under `${CUDA_HOME}/compat-${CUDA_VER}`, and I've correspondingly modified `LD_LIBRARY_PATH` as well (default within the upstream images is `/usr/local/nvidia/lib:/usr/local/nvidia/lib64`).