### PR TITLE
fix wrong ldconfig path from #135

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -13,13 +13,13 @@ ENV LANG en_US.UTF-8
 
 # Set path to CUDA install (this is a symlink to /usr/local/cuda-${CUDA_VER})
 ENV CUDA_HOME /usr/local/cuda
-# the upstream images for 10.x all have libcuda.so under $CUDA_HOME/compat-$CUDA_VER;
+# the upstream images for 10.x all have libcuda.so under $CUDA_HOME/compat;
 # add this to the ldconfig so it will be found correctly. For 9.2, the image
-# nvidia/cuda:9.2-devel-centos6 contains neither $CUDA_HOME/compat-$CUDA_VER,
-# nor any (non-stub) libcuda.so. For licensing reasons, these cannot be part of
-# the conda-forge docker images, but are instead added for CI purposes in:
+# nvidia/cuda:9.2-devel-centos6 contains neither $CUDA_HOME/compat, nor any
+# (non-stub) libcuda.so. For licensing reasons, these cannot be part of the
+# conda-forge docker images, but are instead added for CI purposes in:
 # github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/run_conda_forge_build_setup_linux
-RUN echo "$CUDA_HOME/compat-$CUDA_VER" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf && \
+RUN echo "$CUDA_HOME/compat" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf && \
     ldconfig
 
 # Add a timestamp for the build. Also, bust the cache.


### PR DESCRIPTION
@isuruf

I'm sorry, I managed to confuse myself last night in #135 - the path added to ldconfig is not correct (it's  `/usr/local/cuda-$CUDA_VER/compat` == `$CUDA_HOME/compat` instead of  `$CUDA_HOME/compat-$CUDA_VER`).

The confirmation is here:
```
xxx@yyy:~$ sudo docker run --rm -it condaforge/linux-anvil-cuda:10.2 bash
[conda@750aa8f98caf ~]$ find /usr/ -name 'libcuda.so*'
/usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs/libcuda.so
/usr/local/cuda-10.2/compat/libcuda.so
/usr/local/cuda-10.2/compat/libcuda.so.1
/usr/local/cuda-10.2/compat/libcuda.so.440.64.00
```

Please merge this at your earliest convenience.