### PR TITLE
Avoid shadowing of channels from global .condarc

### DIFF
--- a/scripts/entrypoint
+++ b/scripts/entrypoint
@@ -15,6 +15,11 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/c
 export supkg="su-exec"
 chown conda:conda $HOME
 cp -R /etc/skel $HOME && chown -R conda:conda $HOME/skel && (ls -A1 $HOME/skel | xargs -I {} mv -n $HOME/skel/{} $HOME) && rm -Rf $HOME/skel
+
+# This is needed to have a predictable channel specification used for builds
+# from non-conda-forge channels as conda-smithy does not remove it for us.
+rm -f /opt/conda/.condarc
+
 cp /root/.condarc $HOME/.condarc && chown conda:conda $HOME/.condarc
 cd $HOME
 


### PR DESCRIPTION
## Problem
While working on feedstocks ourside of the conda-forge organization, I sometimes notice that some packages are taken from the conda-forge channel while the channel configuration lists only `nsls2forge` and `defaults`, so the channels selection is not respected.

## Fix
This update may be useful for users of the conda-forge infrastructure who build packages based on the `defaults` and other non-conda-forge channels (e.g., https://github.com/nsls-ii-forge).

## Verification
The proposed approach was tested on a custom Docker image based on https://github.com/nsls-ii-forge/utils/blob/master/nsls2forge-docker/Dockerfile / https://hub.docker.com/repository/docker/nsls2/nsls2forge applied to the following feedstock: https://github.com/nsls-ii-forge/hkl-feedstock/blob/master/recipe/conda_build_config.yaml. I'd definitely prefer using the default images for conda-smithy, but currently they are not fully reusable for other orgs/channels due to the above-mentioned issue.