### PR TITLE
Remove adding qemu interpreter to the docker image 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,19 +94,6 @@ before_install:
       if [ "$(uname -m)" = "x86_64" ]; then
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
       fi
-      export QEMU_STATIC_VERSION=v3.1.0-3
-      qemu_ppc64le_sha256=d018b96e20f7aefbc50e6ba93b6cabfd53490cdf1c88b02e7d66716fa09a7a17
-      qemu_aarch64_sha256=a64b39b8ce16e2285cb130bcba7143e6ad2fe19935401f01c38325febe64104b
-      qemu_arm_sha256=f4184c927f78d23d199056c5b0b6d75855e298410571d65582face3159117901
-      wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-ppc64le-static
-      wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-aarch64-static
-      wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-arm-static
-      sha256sum qemu-ppc64le-static | grep -F "${qemu_ppc64le_sha256}"
-      sha256sum qemu-aarch64-static | grep -F "${qemu_aarch64_sha256}"
-      sha256sum qemu-arm-static | grep -F "${qemu_aarch64_sha256}"
-      chmod +x qemu-ppc64le-static
-      chmod +x qemu-aarch64-static
-      chmod +x qemu-arm-static
 
 install:
     - |

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -1,7 +1,5 @@
 FROM arm64v8/centos:7
 
-ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
-
 LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 
 # Set an encoding to make things work smoothly.

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -12,9 +12,6 @@ LABEL maintainer="conda-forge <conda-forge@googlegroups.com>"
 ARG CUDA_VER
 ENV CUDA_VER ${CUDA_VER}
 
-# Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
-ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
-
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -2,9 +2,6 @@ FROM ppc64le/centos:7
 
 MAINTAINER conda-forge <conda-forge@googlegroups.com>
 
-# Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
-ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
-
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8


### PR DESCRIPTION
The qemu interpreter inside the docker image does nothing.
qemu needs to be installed in the host machine.