### PR TITLE
Tag images with version and latest and consistency check

### DIFF
--- a/.circleci/test_docker_container.sh
+++ b/.circleci/test_docker_container.sh
@@ -14,6 +14,14 @@ touch /opt/conda/bin/test_conda_forge
 # check that conda is activated
 conda info
 
+# check that conda version matches
+IFS='-' read -ra miniforge_version_array <<< "$MINIFORGE_VERSION"
+conda_version=${`conda --version`/conda /""}
+if [[ "${miniforge_version_array[0]}" != "${conda_version}" ]]
+ then
+  exit 1
+fi
+
 # show all packages installed in root
 conda list
 

--- a/.circleci/test_docker_container.sh
+++ b/.circleci/test_docker_container.sh
@@ -14,10 +14,10 @@ touch /opt/conda/bin/test_conda_forge
 # check that conda is activated
 conda info
 
-# check that conda version matches
-IFS='-' read -ra miniforge_version_array <<< "$MINIFORGE_VERSION"
-conda_version=${`conda --version`/conda /""}
-if [[ "${miniforge_version_array[0]}" != "${conda_version}" ]]
+# check that conda version matches release tag
+conda_version=$(conda --version)
+conda_version=${conda_version/conda /""}
+if [[ "${RELEASE_CONDA_VERSION}" != "${conda_version}" ]]
  then
   exit 1
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ before_install:
 
 install:
     - |
-      if [[ $DOCKERTAGSUFFIX == "jnlp-slave" ]]
+      if [[ $DOCKERLATESTTAG == "jnlp-slave" ]]
       then
         sed "s|@BASE_IMAGE@|condaforge/${DOCKERIMAGE}|" jnlp-slave/Dockerfile.in > $DOCKERIMAGE/Dockerfile
       fi
@@ -136,7 +136,7 @@ install:
 
 script:
     - |
-      if [[ $DOCKERTAGSUFFIX != "jnlp-slave" ]]
+      if [[ $DOCKERLATESTTAG != "jnlp-slave" ]]
       then
         ./.circleci/run_docker_build.sh
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,85 +5,106 @@ matrix:
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-comp7
+        - DOCKERLATESTTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-comp7
-        - DOCKERTAGSUFFIX=jnlp-slave
+        - DOCKERLATESTTAG=jnlp-slave
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cos7-x86_64
+        - DOCKERLATESTTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le
+        - DOCKERLATESTTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-aarch64
+        - DOCKERLATESTTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAGSUFFIX=9.2
+        - DOCKERLATESTTAG=9.2
         - CUDA_VER=9.2
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAGSUFFIX=10.0
+        - DOCKERLATESTTAG=10.0
         - CUDA_VER=10.0
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAGSUFFIX=10.1
+        - DOCKERLATESTTAG=10.1
         - CUDA_VER=10.1
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAGSUFFIX=10.2
+        - DOCKERLATESTTAG=10.2
         - CUDA_VER=10.2
 
     - os: linux
       env:
         - DOCKERIMAGE=miniforge3
+        - DOCKERLATESTTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAGSUFFIX=9.2
+        - DOCKERLATESTTAG=9.2
         - CUDA_VER=9.2
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAGSUFFIX=10.0
+        - DOCKERLATESTTAG=10.0
         - CUDA_VER=10.0
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAGSUFFIX=10.1
+        - DOCKERLATESTTAG=10.1
         - CUDA_VER=10.1
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAGSUFFIX=10.2
+        - DOCKERLATESTTAG=10.2
         - CUDA_VER=10.2
 
 env:
   global:
-    - MINIFORGE_VERSION="4.8.3-0"
+    - RELEASE_CONDA_VERSION=4.8.3
+    - RELEASE_BUILD_NUM=0
     secure: "nM8OaFilQkH14wzD1S6DTGejjo3yL/q/1dpz7144Kw68s8FVqW0zsxCC6960ieokY2LutGSv16qTiIFxnRZnHPCXt7X2MhxcagX8IcMu62DWe2jgqwho0hPI65N/bQYLW1l23e9tjKQxWFZopM4Oyzm6TBqlzibTdbPuQI+YB3RBY0dlkIlupPIYtiNlLRR/HnOyyUny/hg3Z65GWeVpXhiMPqXLlfliTiQ31JgBaNuXiP3/ruSCDeyRPWx62IcPGJ1xVSXL3tvkEI2TpGVCsraKCSbgINhm3AHjQ+8ST6GPMxaOaHrKZzssKJpsZhz1dzWINXTLOQ5LrKtBVwfaevFxDmPEr9RcVlzwAAyuWugCyV4Z6NSt/j2Qqw5qGaiiDHyBH0FMmBgzlPzLZ4JKFsZ68aRkc2qV0MeN0YJRwcQ0EnXRULrcwReBztDHZwixSxqlPpQUwbRr7ne05rBjVoMTKaEhyHPO+KYSwQB1wiQgILBtlP/5ofsYc9Eb46m5JJJhJxuLythKpW9mMqd/US4rQrgEHQ/QRIRYwzGnKf/5WXV3W2o4C9QZpH5Da3J7jOLlqxIY5I+Dv9eEk7XxhT7UaEo7C9tmzjaL2D0yrzPnOnPQhMpmCVNWqdTp1eLcIASKSPbmzz8MuYB5yg48wjXWvDIRBQ6hJyuKHhNGE9k="
 
 before_install:
+    # Define the versioned tag
+    - |
+      if [ "$DOCKERLATESTTAG" != "latest" ]; then
+        export DOCKERVERSIONTAG=$RELEASE_CONDA_VERSION-$DOCKERLATESTTAG-$RELEASE_BUILD_NUM
+      else
+        export DOCKERVERSIONTAG=$RELEASE_CONDA_VERSION-$RELEASE_BUILD_NUM
+      fi
+
     # Enable experimental features (needed for squash)
     - sudo cp docker_daemon_config.json /etc/docker/daemon.json
     - sudo service docker restart
+
+    # Fail build is versioned tag already exists (forgot to bump version or build num?)
+    - |
+      if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect condaforge/$DOCKERIMAGE:$DOCKERVERSIONTAG >/dev/null;
+        echo "Versioned tag already exists!"
+        exit 1
+      fi
 
     - docker info
     - |
@@ -111,8 +132,7 @@ install:
       then
         sed "s|@BASE_IMAGE@|condaforge/${DOCKERIMAGE}|" jnlp-slave/Dockerfile.in > $DOCKERIMAGE/Dockerfile
       fi
-    - export DOCKERTAG=$MINIFORGE_VERSION-$DOCKERTAGSUFFIX
-    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:$DOCKERTAG -t condaforge/$DOCKERIMAGE:latest -f $DOCKERIMAGE/Dockerfile --no-cache --squash .
+    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:DOCKERVERSIONTAG -t condaforge/$DOCKERIMAGE:$DOCKERLATESTTAG -f $DOCKERIMAGE/Dockerfile --no-cache --squash .
 
 script:
     - |
@@ -124,7 +144,6 @@ script:
 deploy:
   provider: script
   script: |
-          export DOCKERTAG=$MINIFORGE_VERSION-$DOCKERTAGSUFFIX &&
           docker login -u condaforgebot -p $DH_PASSWORD &&
-          docker push condaforge/$DOCKERIMAGE:$DOCKERTAG &&
-          docker push condaforge/$DOCKERIMAGE:latest
+          docker push condaforge/$DOCKERIMAGE:$DOCKERVERSIONTAG &&
+          docker push condaforge/$DOCKERIMAGE:$DOCKERLATESTTAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,83 +5,79 @@ matrix:
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-comp7
-        - DOCKERTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-comp7
-        - DOCKERTAG=jnlp-slave
+        - DOCKERTAGSUFFIX=jnlp-slave
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cos7-x86_64
-        - DOCKERTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le
-        - DOCKERTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-aarch64
-        - DOCKERTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAG=9.2
+        - DOCKERTAGSUFFIX=9.2
         - CUDA_VER=9.2
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAG=10.0
+        - DOCKERTAGSUFFIX=10.0
         - CUDA_VER=10.0
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAG=10.1
+        - DOCKERTAGSUFFIX=10.1
         - CUDA_VER=10.1
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-cuda
-        - DOCKERTAG=10.2
+        - DOCKERTAGSUFFIX=10.2
         - CUDA_VER=10.2
 
     - os: linux
       env:
         - DOCKERIMAGE=miniforge3
-        - DOCKERTAG=latest
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAG=9.2
+        - DOCKERTAGSUFFIX=9.2
         - CUDA_VER=9.2
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAG=10.0
+        - DOCKERTAGSUFFIX=10.0
         - CUDA_VER=10.0
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAG=10.1
+        - DOCKERTAGSUFFIX=10.1
         - CUDA_VER=10.1
 
     - os: linux
       env:
         - DOCKERIMAGE=linux-anvil-ppc64le-cuda
-        - DOCKERTAG=10.2
+        - DOCKERTAGSUFFIX=10.2
         - CUDA_VER=10.2
 
 env:
   global:
+    - MINIFORGE_VERSION="4.8.3-0"
     secure: "nM8OaFilQkH14wzD1S6DTGejjo3yL/q/1dpz7144Kw68s8FVqW0zsxCC6960ieokY2LutGSv16qTiIFxnRZnHPCXt7X2MhxcagX8IcMu62DWe2jgqwho0hPI65N/bQYLW1l23e9tjKQxWFZopM4Oyzm6TBqlzibTdbPuQI+YB3RBY0dlkIlupPIYtiNlLRR/HnOyyUny/hg3Z65GWeVpXhiMPqXLlfliTiQ31JgBaNuXiP3/ruSCDeyRPWx62IcPGJ1xVSXL3tvkEI2TpGVCsraKCSbgINhm3AHjQ+8ST6GPMxaOaHrKZzssKJpsZhz1dzWINXTLOQ5LrKtBVwfaevFxDmPEr9RcVlzwAAyuWugCyV4Z6NSt/j2Qqw5qGaiiDHyBH0FMmBgzlPzLZ4JKFsZ68aRkc2qV0MeN0YJRwcQ0EnXRULrcwReBztDHZwixSxqlPpQUwbRr7ne05rBjVoMTKaEhyHPO+KYSwQB1wiQgILBtlP/5ofsYc9Eb46m5JJJhJxuLythKpW9mMqd/US4rQrgEHQ/QRIRYwzGnKf/5WXV3W2o4C9QZpH5Da3J7jOLlqxIY5I+Dv9eEk7XxhT7UaEo7C9tmzjaL2D0yrzPnOnPQhMpmCVNWqdTp1eLcIASKSPbmzz8MuYB5yg48wjXWvDIRBQ6hJyuKHhNGE9k="
 
 before_install:
@@ -111,19 +107,24 @@ before_install:
 
 install:
     - |
-      if [[ $DOCKERTAG == "jnlp-slave" ]]
+      if [[ $DOCKERTAGSUFFIX == "jnlp-slave" ]]
       then
         sed "s|@BASE_IMAGE@|condaforge/${DOCKERIMAGE}|" jnlp-slave/Dockerfile.in > $DOCKERIMAGE/Dockerfile
       fi
-    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:$DOCKERTAG -f $DOCKERIMAGE/Dockerfile --no-cache --squash .
+    - export DOCKERTAG=$MINIFORGE_VERSION-$DOCKERTAGSUFFIX
+    - docker build --build-arg CUDA_VER -t condaforge/$DOCKERIMAGE:$DOCKERTAG -t condaforge/$DOCKERIMAGE:latest -f $DOCKERIMAGE/Dockerfile --no-cache --squash .
 
 script:
     - |
-      if [[ $DOCKERTAG != "jnlp-slave" ]]
+      if [[ $DOCKERTAGSUFFIX != "jnlp-slave" ]]
       then
         ./.circleci/run_docker_build.sh
       fi
 
 deploy:
   provider: script
-  script: docker login -u condaforgebot -p $DH_PASSWORD && docker push condaforge/$DOCKERIMAGE:$DOCKERTAG
+  script: |
+          export DOCKERTAG=$MINIFORGE_VERSION-$DOCKERTAGSUFFIX &&
+          docker login -u condaforgebot -p $DH_PASSWORD &&
+          docker push condaforge/$DOCKERIMAGE:$DOCKERTAG &&
+          docker push condaforge/$DOCKERIMAGE:latest


### PR DESCRIPTION
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes https://github.com/conda-forge/docker-images/issues/43
<!--
Please add any other relevant info below:
-->

I don't know if this is on the right path, but it was an attempt at addressing the issue raised in https://github.com/conda-forge/docker-images/issues/43. @isuruf is this along the lines of what you imagined?

All images would be tagged both by:
`<MINIFORGE_VERSION><optional-suffix (eg. cuda version)>`
`latest`

One of the requested features was "The version tag is automatically updated so that we don't have to bump it every time." I don't address this here -- one would need to either modify scripts/run_commands to dynamically respect the version in .travis.yml, but that wouldn't work due to the sha256 checking, and conversely if the value would be set by scripts/run_commands, how would .travis.yml pick that up? If someone has an idea how to make this better, I'm happy to try.