### PR TITLE
ENH push to quay too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,4 +126,9 @@ script:
 
 deploy:
   provider: script
-  script: docker login -u condaforgebot -p $DH_PASSWORD && docker push condaforge/$DOCKERIMAGE:$DOCKERTAG
+  script: |
+    docker login -u condaforgebot -p $DH_PASSWORD && \
+      docker push condaforge/$DOCKERIMAGE:$DOCKERTAG
+    docker login -u conda_forge_daemon -p ${CFD_QUAY_PASSWORD} && \
+      docker tag condaforge/$DOCKERIMAGE:$DOCKERTAG quay.io/condaforge/$DOCKERIMAGE:$DOCKERTAG && \
+      docker push quay.io/condaforge/$DOCKERIMAGE:$DOCKERTAG

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![CircleCI](https://circleci.com/gh/conda-forge/docker-images/tree/master.svg?style=shield)](https://circleci.com/gh/conda-forge/docker-images/tree/master)
-[![Docker Repository on Quay](https://quay.io/repository/condaforge/linux-anvil/status "Docker Repository on Quay")](https://quay.io/repository/condaforge/linux-anvil)
-[![Travis CI Build Status](https://travis-ci.org/conda-forge/docker-images.svg?branch=master)](https://travis-ci.org/conda-forge/docker-images)
+[![Travis CI Build Status](https://travis-ci.com/conda-forge/docker-images.svg?branch=master)](https://travis-ci.com/conda-forge/docker-images)
 
 # docker-images
 Repository to host the Docker images files used in conda-forge


### PR DESCRIPTION
I am enabling pushes to quay as images are built. This way if docker hub starts rate limiting our CI jobs, we can move to quay instead.