### PR TITLE
Disable `cuda` repo during `yum update`

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -46,7 +46,7 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 
 # Install basic requirements.
 COPY scripts/yum_clean_all /opt/docker/bin/
-RUN yum update -y && \
+RUN yum update -y --disablerepo=cuda && \
     yum install -y \
         bzip2 \
         sudo \

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -34,7 +34,7 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 
 # Install basic requirements.
 COPY scripts/yum_clean_all /opt/docker/bin/
-RUN yum update -y && \
+RUN yum update -y --disablerepo=cuda && \
     yum install -y \
         bzip2 \
         sudo \


### PR DESCRIPTION
With CUDA 10.1, the `libcublas` package is broken by running `yum update`. So simply disable updates related to the `cuda` `yum` repo to avoid this breakage.

cc @leofang

xref: https://github.com/conda-forge/cupy-feedstock/pull/70
xref: https://github.com/rapidsai/gpuci-build-environment/pull/123