### PR TITLE
Update qemu-static to 5.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,23 +140,7 @@ jobs:
 
       - name: Configure qemu
         run: |
-          set -xe
-          if [ "$(uname -m)" = "x86_64" ]; then
-              docker run --rm --privileged multiarch/qemu-user-static:register --reset
-          fi
-          export QEMU_STATIC_VERSION=v3.1.0-3
-          qemu_ppc64le_sha256=d018b96e20f7aefbc50e6ba93b6cabfd53490cdf1c88b02e7d66716fa09a7a17
-          qemu_aarch64_sha256=a64b39b8ce16e2285cb130bcba7143e6ad2fe19935401f01c38325febe64104b
-          qemu_arm_sha256=f4184c927f78d23d199056c5b0b6d75855e298410571d65582face3159117901
-          wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-ppc64le-static
-          wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-aarch64-static
-          wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-arm-static
-          sha256sum qemu-ppc64le-static | grep -F "${qemu_ppc64le_sha256}"
-          sha256sum qemu-aarch64-static | grep -F "${qemu_aarch64_sha256}"
-          sha256sum qemu-arm-static | grep -F "${qemu_arm_sha256}"
-          chmod +x qemu-ppc64le-static
-          chmod +x qemu-aarch64-static
-          chmod +x qemu-arm-static
+          ./download-qemu-static.sh
 
       - name: Patch for jnlp-slave
         if: matrix.cfg.DOCKERTAG == 'jnlp-slave'

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -ex
+
+set -xe
+if [ "$(uname -m)" == "x86_64" ]; then
+    docker run --rm --privileged multiarch/qemu-user-static:register --reset
+fi
+
+export QEMU_STATIC_VERSION=v5.1.0-8
+qemu_aarch64_sha256=58f25aa64f433225145226cc03a10b1177da8ece5c4a6b0fe38626c29093804a
+qemu_arm_sha256=fa2d1f9794eac9c069b65d27b09ee0a12c82d2abac54434c531b9c8a497a611a
+qemu_ppc64le_sha256=9f19aaf037a992dcfdb87eb8dafc03189d5b238398a2c2014e166c06a8586e4f
+
+set +e
+rm qemu-*-static
+set -e
+
+wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-aarch64-static
+wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-arm-static
+wget https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_STATIC_VERSION}/qemu-ppc64le-static
+
+sha256sum qemu-*-static
+
+sha256sum qemu-aarch64-static | grep -F "${qemu_aarch64_sha256}"
+sha256sum qemu-arm-static | grep -F "${qemu_arm_sha256}"
+sha256sum qemu-ppc64le-static | grep -F "${qemu_ppc64le_sha256}"
+
+chmod +x qemu-aarch64-static
+chmod +x qemu-arm-static
+chmod +x qemu-ppc64le-static

--- a/linux-anvil-cos7-x86_64/Dockerfile
+++ b/linux-anvil-cos7-x86_64/Dockerfile
@@ -9,6 +9,11 @@ ENV CENTOS_VER=${CENTOS_VER}
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 
+# Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
+ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
+ADD qemu-arm-static /usr/bin/qemu-arm-static
+ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
+
 # bust the docker cache so that we always rerun the installs below
 ADD http://www.randomtext.me/api/gibberish /opt/docker/etc/gibberish
 


### PR DESCRIPTION
This should reduce some errors seen in emulation-based builds compared to our old pin from 2 years ago.

Additionally added the qemu-static binaries to our cos7-x68_64 image

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
