### PR TITLE
ENH Add CUDA 11.2 support and update nvidia/cuda docker tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,11 @@ jobs:
           CUDA_VER: "11.1"
           CENTOS_VER: "7"
 
+        - DOCKERIMAGE: linux-anvil-cuda
+          DOCKERTAG: "11.2"
+          CUDA_VER: "11.2.0"
+          CENTOS_VER: "7"
+
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "9.2"
           CUDA_VER: "9.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,12 +80,12 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.0"
-          CUDA_VER: "11.0"
+          CUDA_VER: "11.0.3"
           CENTOS_VER: "7"
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.1"
-          CUDA_VER: "11.1"
+          CUDA_VER: "11.1.1"
           CENTOS_VER: "7"
 
         - DOCKERIMAGE: linux-anvil-cuda

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ docker build --rm --build-arg CENTOS_VER=6 --build-arg CUDA_VER=10.2 -f linux-an
 ## Environment variables
 
 * `$CUDA_VER`: This is the cuda & cudatoolkit version that will be used. The
-  value of this variable should be in major-minor for, e.g. `9.2`.
+  value of this variable should be in major-minor for, e.g. `9.2` for versions
+  `9.x` and `10.x`. For versions `11.x` the variable should be in
+  major-minor-patch format, e.g. `11.2.0`.
 * `CENTOS_VER`: This is version of CentOS that the image should be built with.
   This is the major-only version number, e.g. `6` or `7`.  You'll usually want
   to build with the lowest working value for maximum compatibility.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
- Adds CUDA 11.2 support
- Updates docker tags used in `nvidia/cuda` which now include the [patch version](https://hub.docker.com/r/nvidia/cuda) for versions 11.0+

**NOTE:** This changes the use of `CUDA_VER` for CUDA `11.x`; open on suggestions as to whether the [documentation change](https://github.com/conda-forge/docker-images/pull/171/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R29) is enough or there needs to be a new variable for the `nvidia/cuda` tag with major-minor-patch instead of using `CUDA_VER` as it may have unintended impacts.

cc @jakirkham 
