### PR TITLE
PPC: add 11.0, 11.1, 11.2 + cached cudatoolkit pkg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,21 @@ jobs:
           CENTOS_VER: "7"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "9.2"
+          CUDA_VER: "9.2"
+          CENTOS_VER: "7"
+
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "10.0"
+          CUDA_VER: "10.0"
+          CENTOS_VER: "7"
+
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "10.1"
+          CUDA_VER: "10.1"
+          CENTOS_VER: "7"
+
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "10.2"
           CUDA_VER: "10.2"
           CENTOS_VER: "7"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,24 +90,19 @@ jobs:
           CENTOS_VER: "7"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "9.2"
-          CUDA_VER: "9.2"
-          CENTOS_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "10.0"
-          CUDA_VER: "10.0"
-          CENTOS_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "10.1"
-          CUDA_VER: "10.1"
-          CENTOS_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "10.2"
           CUDA_VER: "10.2"
           CENTOS_VER: "7"
+
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "11.0"
+          CUDA_VER: "11.0"
+          CENTOS_VER: "8"
+
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "11.1"
+          CUDA_VER: "11.1"
+          CENTOS_VER: "8"
 
     env:
       DOCKERIMAGE: ${{ matrix.cfg.DOCKERIMAGE }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,11 @@ jobs:
           CUDA_VER: "11.1"
           CENTOS_VER: "8"
 
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "11.2"
+          CUDA_VER: "11.2.2"
+          CENTOS_VER: "8"
+
     env:
       DOCKERIMAGE: ${{ matrix.cfg.DOCKERIMAGE }}
       DOCKERFILE: ${{ matrix.cfg.DOCKERFILE }}

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -28,13 +28,14 @@ ENV CUDA_HOME /usr/local/cuda
 ADD http://www.randomtext.me/api/gibberish /opt/docker/etc/gibberish
 
 # Resolves a nasty NOKEY warning that appears when using yum.
-# Naming convention changed with cos8 - see https://lists.centos.org/pipermail/centos-devel/2019-September/017847.html
+# Naming convention changed with cos8 - see:
+# * https://lists.centos.org/pipermail/centos-devel/2019-September/017847.html
+# * https://www.centos.org/keys/#project-keys
 RUN if [ "$CENTOS_VER" -le "7" ]; then \
         rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER} && \
         rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-${CENTOS_VER}-ppc64le; \
     else \
-        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
-        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-centosofficial-ppc64le; \
+        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial; \
     fi
 
 # Remove preinclude system compilers

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -69,6 +69,17 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda
 
+# Download and cache CUDA related packages.
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate && \
+    conda create -n test --yes --quiet --download-only \
+        conda-forge::cudatoolkit=${CUDA_VER} \
+        && \
+    conda remove --yes --quiet -n test --all && \
+    conda clean -tiy && \
+    chgrp -R lucky /opt/conda && \
+    chmod -R g=u /opt/conda
+
 # Add a file for users to source to activate the `conda`
 # environment `root`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -48,8 +48,17 @@ RUN yum update -y --disablerepo=cuda && \
         bzip2 \
         sudo \
         tar \
-        which && \
+        which \
+        && \
     /opt/docker/bin/yum_clean_all
+
+# Fix locale in CentOS8 images
+# See https://github.com/CentOS/sig-cloud-instance-images/issues/154
+RUN if [ "$CENTOS_VER" -ge "8" ]; then \
+        yum install -y glibc-langpack-en \
+        && \
+        /opt/docker/bin/yum_clean_all; \
+    fi
 
 # Run common commands
 COPY scripts/run_commands /opt/docker/bin/run_commands

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -28,8 +28,14 @@ ENV CUDA_HOME /usr/local/cuda
 ADD http://www.randomtext.me/api/gibberish /opt/docker/etc/gibberish
 
 # Resolves a nasty NOKEY warning that appears when using yum.
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER} && \
-    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-${CENTOS_VER}-ppc64le
+# Naming convention changed with cos8 - see https://lists.centos.org/pipermail/centos-devel/2019-September/017847.html
+RUN if [ "$CENTOS_VER" -le "7" ]; then \
+        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER} && \
+        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-${CENTOS_VER}-ppc64le; \
+    else \
+        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-centosofficial-ppc64le; \
+    fi
 
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -77,15 +77,19 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     chmod -R g=u /opt/conda
 
 # Download and cache CUDA related packages.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::cudatoolkit=${CUDA_VER} \
-        && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
+RUN if [[ "$CUDA_VER" == "9.2" || "$CUDA_VER" == "10.0" || "$CUDA_VER" == "10.1" ]]; then \
+        echo "`cudatoolkit` not available for CUDA_VER<10.2"; \
+    else \
+        source /opt/conda/etc/profile.d/conda.sh && \
+        conda activate && \
+        conda create -n test --yes --quiet --download-only \
+            conda-forge::cudatoolkit=${CUDA_VER} \
+            && \
+        conda remove --yes --quiet -n test --all && \
+        conda clean -tiy && \
+        chgrp -R lucky /opt/conda && \
+        chmod -R g=u /opt/conda; \
+    fi
 
 # Add a file for users to source to activate the `conda`
 # environment `root`. Also add a file that wraps that for


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I am adding PPC64LE images for CUDA 11.0 and 11.1, with cached `cudatoolkit` too. Since we are not packaging `cudatoolkit` for <10.2 (see https://github.com/conda-forge/cudatoolkit-feedstock/issues/12), those won't cache it.