### PR TITLE
PPC: add $CUDA_HOME/bin to $PATH

### DIFF
--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -24,6 +24,27 @@ ENV LANGUAGE=en_US.UTF-8
 # Set path to CUDA install.
 ENV CUDA_HOME /usr/local/cuda
 
+# we want to persist a path in ldconfig (to avoid having to always set LD_LIBRARY_PATH), but *after* the existing entries;
+# since entries in ld.so.conf.d have precedence before the preconfigured directories, we first add the latter to the former
+RUN ldconfig -v 2>/dev/null | grep -v ^$'\t' | cut -f1 -d":" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf \
+    && if [ ${CUDA_VER} != "9.2" ]; then \
+        # the upstream images for 10.x all have libcuda.so under $CUDA_HOME/compat;
+        # add this to the ldconfig so it will be found correctly.
+        echo "$CUDA_HOME/compat" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf ; \
+    else \
+        # For 9.2, the image nvidia/cuda:9.2-devel-centos6 contains neither
+        # $CUDA_HOME/compat, nor any (non-stub) libcuda.so. We fix this by
+        # adding cuda-compat-10.0 (which is not used for building, but to
+        # test if loading the respective library/package works). However,
+        # due to licensing reasons, these cannot be part of the conda-forge
+        # docker images, but are instead added for CI purposes in:
+        # github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/run_conda_forge_build_setup_linux
+        # Here we only set the ldconfig accordingly.
+        echo "/usr/local/cuda-10.0/compat" >> /etc/ld.so.conf.d/cuda-$CUDA_VER.conf ; \
+    fi \
+    # don't forget to update settings by running ldconfig
+    && ldconfig
+
 # bust the docker cache so that we always rerun the installs below
 ADD http://www.randomtext.me/api/gibberish /opt/docker/etc/gibberish
 

--- a/linux-anvil-ppc64le-cuda/entrypoint_source
+++ b/linux-anvil-ppc64le-cuda/entrypoint_source
@@ -1,2 +1,5 @@
+# Add `CUDA_HOME` binaries to `PATH`.
+export PATH="${PATH}:${CUDA_HOME}/bin"
+
 # Activate the `base` conda environment.
 conda activate base


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

PPC CUDA images were not exporting `$CUDA_HOME/bin` to `$PATH`, which prevents `cuda-gdb` from being found by our `nvcc` wrapper when it is trying to detect `$CUDA_HOME`.
