### PR TITLE
Add linux-anvil-aarch64 centos8 image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,10 @@ jobs:
           DOCKERTAG: latest
           CENTOS_VER: "7"
 
+        - DOCKERIMAGE: linux-anvil-aarch64
+          DOCKERTAG: "centos8"
+          CENTOS_VER: "8"
+
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "9.2"
           CUDA_VER: "9.2"

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -16,12 +16,28 @@ ENV LANGUAGE=en_US.UTF-8
 ADD https://loripsum.net/api /opt/docker/etc/gibberish
 
 # Resolves a nasty NOKEY warning that appears when using yum.
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER} && \
-    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER}-aarch64
+RUN if [ "$(rpm --eval %{centos_ver})" = "7" ]; then \
+      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER} && \
+      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER}-aarch64; \
+    elif [ "$(rpm --eval %{centos_ver})" = "8" ]; then \
+      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial; \
+    else \
+      echo "Unsupported centos version" && \
+      exit 1; \
+    fi
 
-# (arm64v8/centos:7 only) Fix language override to get a working en_US.UTF-8 locale; backports:
+# (arm64v8/centos:7) Fix language override to get a working en_US.UTF-8 locale; backports:
 # https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670
-RUN sed -i 's/override_install_langs=en_US\.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf
+# (arm64v8/centos:8) Install glibc-langpack-en package to get a working en_US.UTF-8 locale
+RUN if [ "$(rpm --eval %{centos_ver})" = "7" ]; then \
+      sed -i 's/override_install_langs=en_US\.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf; \
+    elif [ "$(rpm --eval %{centos_ver})" = "8" ]; then \
+      yum install -y glibc-langpack-en; \
+    else \
+      echo "Unsupported centos version" && \
+      exit 1; \
+    fi
+
 # Install basic requirements.
 COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y && \


### PR DESCRIPTION
Add `linux-anvil-aarch64` `centos8` based image.

I think this is required to build packages for `aarch64` that require `glibc >= 2.28`

I had to change `www.randomtext.me` to `loripsum.net` as it seems to be down for a long time.

I used the `centos8` docker tag, but I'm open to any idea here.
