### PR TITLE
Enable strict channel priority in Docker images

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -32,6 +32,7 @@ ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
 source /opt/conda/etc/profile.d/conda.sh
 conda activate
 conda config --set show_channel_urls True
+conda config --set channel_priority strict
 conda config ${additional_channel} --add channels conda-forge
 conda config --show-sources
 conda update --all --yes


### PR DESCRIPTION
This adds strict channel priority to the Docker images by default. Should resolve install issues like this one ( https://github.com/conda-forge/ctng-compilers-feedstock/issues/63 ).

On CI this is [overridden by this line]( https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/42a5c27a532bac0af40f329e64c9df36e3ebaaa4/recipe/run_conda_forge_build_setup_linux#L23-L27 ).

cc @beckermr