### PR TITLE
Add mamba and boa into the base environment.

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,7 +41,8 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
-    python=3.8 setuptools conda-build anaconda-client
+    python=3.8 setuptools conda-build anaconda-client \
+    mamba boa
 conda clean -tipy
 
 # Install docker tools


### PR DESCRIPTION
This should start unblocking us from making using of conda mamba-build on some of our builds

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
