### PR TITLE
Add CUDA `11.5` variants to CI axis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.0"
+          CUDA_VER: "11.5.1"
           CENTOS_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
@@ -151,7 +151,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.0"
+          CUDA_VER: "11.5.1"
           CENTOS_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
@@ -181,7 +181,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.0"
+          CUDA_VER: "11.5.1"
           CENTOS_VER: "8"
 
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.5"
           CUDA_VER: "11.5.0"
-          CENTOS_VER: "7"
+          CENTOS_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "9.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,11 @@ jobs:
           CUDA_VER: "11.4.2"
           CENTOS_VER: "7"
 
+        - DOCKERIMAGE: linux-anvil-cuda
+          DOCKERTAG: "11.5"
+          CUDA_VER: "11.5.0"
+          CENTOS_VER: "7"
+
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "9.2"
           CUDA_VER: "9.2"
@@ -144,6 +149,11 @@ jobs:
           CUDA_VER: "11.4.2"
           CENTOS_VER: "8"
 
+        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
+          DOCKERTAG: "11.5"
+          CUDA_VER: "11.5.0"
+          CENTOS_VER: "8"
+
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.0"
           CUDA_VER: "11.0.3"
@@ -167,6 +177,11 @@ jobs:
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.4"
           CUDA_VER: "11.4.2"
+          CENTOS_VER: "8"
+
+        - DOCKERIMAGE: linux-anvil-aarch64-cuda
+          DOCKERTAG: "11.5"
+          CUDA_VER: "11.5.0"
           CENTOS_VER: "8"
 
     env:

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -48,7 +48,7 @@ RUN ldconfig -v 2>/dev/null | grep -v ^$'\t' | cut -f1 -d":" >> /etc/ld.so.conf.
 ADD https://loripsum.net/api /opt/docker/etc/gibberish
 
 # Resolves a nasty NOKEY warning that appears when using yum.
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${CENTOS_VER}
+RUN find /etc/pki/rpm-gpg/ -type f | xargs -I {} rpm --import "{}"
 
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The `nvidia/cuda` version `11.5` images aren't out quite yet, but this PR prepares the `conda-forge` Docker images for when they do come out :slightly_smiling_face:.


