### PR TITLE
Add weekly GH Action cron job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "0 7 * * *"  # everyday 0700 UTC
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: "0 7 * * *"  # everyday 0700 UTC
+    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
 
 jobs:
   build:


### PR DESCRIPTION
Not sure how this was configured to run cron jobs before, but this moves it into GH Actions. Runs [once weekly on Sunday at 0600 UTC]( https://crontab.guru/#0_6_*_*_SUN ), which  should hopefully be a lowish traffic time. Happy to change though if there are preferences

Note: It appears the images haven't been rebuilt in roughly 1 month.