### PR TITLE
Update to Python 3.9 & drop unneeded packages

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -42,7 +42,8 @@ conda clean -tipy
 conda install --yes --quiet \
     git patch \
     python=3.9 \
-    boa conda-build anaconda-client
+    mamba boa \
+    conda-build anaconda-client
 conda clean -tipy
 
 # Install docker tools

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,8 +41,7 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
-    conda-build anaconda-client \
-    boa
+    boa conda-build anaconda-client
 conda clean -tipy
 
 # Install docker tools

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,6 +41,7 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
+    python=3.9 \
     boa conda-build anaconda-client
 conda clean -tipy
 

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,7 +41,7 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
-    python=3.8 setuptools conda-build anaconda-client \
+    python=3.8 conda-build anaconda-client \
     mamba boa
 conda clean -tipy
 

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -42,7 +42,7 @@ conda clean -tipy
 conda install --yes --quiet \
     git patch \
     python=3.8 conda-build anaconda-client \
-    mamba boa
+    boa
 conda clean -tipy
 
 # Install docker tools

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,7 +41,7 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
-    python=3.8 conda-build anaconda-client \
+    conda-build anaconda-client \
     boa
 conda clean -tipy
 

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,7 +41,7 @@ conda clean -tipy
 # Install conda build and deployment tools.
 conda install --yes --quiet \
     git patch \
-    python=3.9 \
+    python=3.9 pip \
     mamba boa \
     conda-build anaconda-client
 conda clean -tipy


### PR DESCRIPTION
* Drops an older `python` version pin (the current installer include `python=3.9`)
* Drops `setuptools` as it is unneeded
* Adds `pip` which is used in some places

Closes https://github.com/conda-forge/docker-images/issues/112