### PR TITLE
Add `$CUDA_HOME/bin` to `PATH` in CUDA ARM images

### DIFF
--- a/linux-anvil-aarch64-cuda/entrypoint_source
+++ b/linux-anvil-aarch64-cuda/entrypoint_source
@@ -1,2 +1,5 @@
+# Add `CUDA_HOME` binaries to `PATH`.
+export PATH="${PATH}:${CUDA_HOME}/bin"
+
 # Activate the `base` conda environment.
 conda activate base


### PR DESCRIPTION
Analogous to the change in PR ( https://github.com/conda-forge/docker-images/pull/181 ). Needed to discover CUDA Toolkit executables.