### PR TITLE
Use CentOS 7 for CUDA 11.5 images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.5"
           CUDA_VER: "11.5.1"
-          CENTOS_VER: "8"
+          CENTOS_VER: "7"
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.6"


### PR DESCRIPTION
Fixes https://github.com/conda-forge/docker-images/issues/205

Previously only CentOS 8 images were available for CUDA 11.5. So we used those. However we would prefer to use CentOS 7 images where possible (and do for other CUDA versions on `x86_64`). Now that CentOS 7 images are available for CUDA 11.5, switch to those.