### PR TITLE
Copy `entrypoint_source` next to `Dockerfile`

### DIFF
--- a/linux-anvil-aarch64-cuda/Dockerfile
+++ b/linux-anvil-aarch64-cuda/Dockerfile
@@ -108,7 +108,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
 # Add a file for users to source to activate the `conda`
 # environment `root`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.
-COPY linux-anvil-aarch64/entrypoint_source /opt/docker/bin/entrypoint_source
+COPY linux-anvil-aarch64-cuda/entrypoint_source /opt/docker/bin/entrypoint_source
 COPY scripts/entrypoint /opt/docker/bin/entrypoint
 
 # Ensure that all containers start with tini and the user selected process.

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -132,7 +132,7 @@ RUN if [[ "$CUDA_VER" == "9.2" || "$CUDA_VER" == "10.0" || "$CUDA_VER" == "10.1"
 # Add a file for users to source to activate the `conda`
 # environment `root`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.
-COPY linux-anvil-ppc64le/entrypoint_source /opt/docker/bin/entrypoint_source
+COPY linux-anvil-ppc64le-cuda/entrypoint_source /opt/docker/bin/entrypoint_source
 COPY scripts/entrypoint /opt/docker/bin/entrypoint
 
 # Ensure that all containers start with tini and the user selected process.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/docker-images/issues/184

As this was copying the `entrypoint_source` files from the non-CUDA Docker images, it was only activating Conda and not adding CUDA executables to the `$PATH`.