### PR TITLE
Skip `cuda` repo update & use `yum_clean_all` in CUDA arch images

### DIFF
--- a/linux-anvil-aarch64-cuda/Dockerfile
+++ b/linux-anvil-aarch64-cuda/Dockerfile
@@ -45,6 +45,9 @@ RUN if [ "$CENTOS_VER" -le "7" ]; then \
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
+# Add custom `yum_clean_all` script before using `yum`
+COPY scripts/yum_clean_all /opt/docker/bin/
+
 # Fallback to CentOS vault for CentOS 8 support.
 RUN if [ "$CENTOS_VER" -eq "8" ]; then \
         find /etc/yum.repos.d/ -name "CentOS-*.repo" -exec \
@@ -54,7 +57,6 @@ RUN if [ "$CENTOS_VER" -eq "8" ]; then \
     fi
 
 # Install basic requirements.
-COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y --disablerepo=cuda && \
     yum install -y \
         bzip2 \

--- a/linux-anvil-aarch64-cuda/Dockerfile
+++ b/linux-anvil-aarch64-cuda/Dockerfile
@@ -49,7 +49,7 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 RUN if [ "$CENTOS_VER" -eq "8" ]; then \
         find /etc/yum.repos.d/ -name "CentOS-*.repo" -exec \
              sed -i 's/mirrorlist/#mirrorlist/g;s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' {} \; && \
-        yum update -y && \
+        yum update -y --disablerepo=cuda && \
         yum clean all; \
     fi
 

--- a/linux-anvil-aarch64-cuda/Dockerfile
+++ b/linux-anvil-aarch64-cuda/Dockerfile
@@ -53,7 +53,7 @@ RUN if [ "$CENTOS_VER" -eq "8" ]; then \
         find /etc/yum.repos.d/ -name "CentOS-*.repo" -exec \
              sed -i 's/mirrorlist/#mirrorlist/g;s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' {} \; && \
         yum update -y --disablerepo=cuda && \
-        yum clean all; \
+        /opt/docker/bin/yum_clean_all; \
     fi
 
 # Install basic requirements.

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -70,7 +70,7 @@ RUN if [ "$CENTOS_VER" -eq "8" ]; then \
         find /etc/yum.repos.d/ -name "CentOS-*.repo" -exec \
              sed -i 's/mirrorlist/#mirrorlist/g;s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' {} \; && \
         yum update -y --disablerepo=cuda && \
-        yum clean all; \
+        /opt/docker/bin/yum_clean_all; \
     fi
 
 # Install basic requirements.

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -66,7 +66,7 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 RUN if [ "$CENTOS_VER" -eq "8" ]; then \
         find /etc/yum.repos.d/ -name "CentOS-*.repo" -exec \
              sed -i 's/mirrorlist/#mirrorlist/g;s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' {} \; && \
-        yum update -y && \
+        yum update -y --disablerepo=cuda && \
         yum clean all; \
     fi
 

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -62,6 +62,9 @@ RUN if [ "$CENTOS_VER" -le "7" ]; then \
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
+# Add custom `yum_clean_all` script before using `yum`
+COPY scripts/yum_clean_all /opt/docker/bin/
+
 # Fallback to CentOS vault for CentOS 8 support.
 RUN if [ "$CENTOS_VER" -eq "8" ]; then \
         find /etc/yum.repos.d/ -name "CentOS-*.repo" -exec \
@@ -71,7 +74,6 @@ RUN if [ "$CENTOS_VER" -eq "8" ]; then \
     fi
 
 # Install basic requirements.
-COPY scripts/yum_clean_all /opt/docker/bin/
 RUN yum update -y --disablerepo=cuda && \
     yum install -y \
         bzip2 \


### PR DESCRIPTION
Makes a couple fixes to CentOS 8 Vault workaround in CUDA arch images:

* Disables the `cuda` repo in the `yum update` call
* Move `COPY` of `yum_clean_all` earlier
* Calls `yum_clean_all` in CentOS 8 workaround