### PR TITLE
Enable CI restart & rebuild for new `git`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
+  workflow_dispatch: null
 
 jobs:
   build:


### PR DESCRIPTION
Adds a button on CI to enable kicking off a build of the image manually when needed.

Also `git` [fixed some CVEs recently]( https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/ ) in `2.39.1` ( https://github.com/conda-forge/git-feedstock/pull/127 ). The new package is in conda-forge, but we need a rebuild of the image to get it.

Finally rebuild to get `conda-build` repodata patch for `setuptools` ( https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/387 ).