### PR TITLE
also add copying from /usr/local/cuda-11.2/targets/* to sudoers

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -25,6 +25,9 @@ echo 'conda ALL=NOPASSWD: /usr/bin/yum' >> /etc/sudoers
 echo 'conda ALL=NOPASSWD: /usr/bin/cp -r /opt/conda/targets/x86_64-linux /usr/local/cuda/targets/x86_64-linux' >> /etc/sudoers
 echo 'conda ALL=NOPASSWD: /usr/bin/cp -r /opt/conda/targets/ppc64le-linux /usr/local/cuda/targets/ppc64le-linux' >> /etc/sudoers
 echo 'conda ALL=NOPASSWD: /usr/bin/cp -r /opt/conda/targets/sbsa-linux /usr/local/cuda/targets/sbsa-linux' >> /etc/sudoers
+echo 'conda ALL=NOPASSWD: /usr/bin/cp -r /usr/local/cuda-11.2/targets/x86_64-linux /usr/local/cuda/targets/x86_64-linux' >> /etc/sudoers
+echo 'conda ALL=NOPASSWD: /usr/bin/cp -r /usr/local/cuda-11.2/targets/ppc64le-linux /usr/local/cuda/targets/ppc64le-linux' >> /etc/sudoers
+echo 'conda ALL=NOPASSWD: /usr/bin/cp -r /usr/local/cuda-11.2/targets/sbsa-linux /usr/local/cuda/targets/sbsa-linux' >> /etc/sudoers
 
 # Install the latest Miniconda with Python 3 and update everything.
 curl -s -L $condapkg > miniconda.sh


### PR DESCRIPTION
Follow-up to #229, as https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/210 still ran into an error
```
+++ mv ./usr/local/cuda-11.2/targets/sbsa-linux /usr/local/cuda/targets/sbsa-linux
mv: cannot move ‘./usr/local/cuda-11.2/targets/sbsa-linux’ to ‘/usr/local/cuda/targets/sbsa-linux’: Permission denied
```

I'm not sure if we want to replace the commands added in #229 completely, for now I just added the equivalents that are copying from `/usr/local/cuda-11.2/targets` instead of `/opt/conda/targets`.

CC @isuruf @jakirkham 