### PR TITLE
Disable keep-alive job on forks

### DIFF
--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   keep-alive:
     name: Alive
+    if: github.repository == 'conda-forge/docker-images'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently keep-alive job runs on any repo (including forks), which means it is pushing commits to those forks. This behavior is only needed on the main repo to ensure cron jobs continue to run (even if there hasn't been much activity on this repo). Forks don't have this need. So disable this job on forks.