### PR TITLE
Refresh CUDA Docker images based on EOL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,13 +121,13 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.1"
+          CUDA_VER: "11.5.2"
           DISTRO_NAME: "centos"
           DISTRO_VER: "7"
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.6"
-          CUDA_VER: "11.6.0"
+          CUDA_VER: "11.6.2"
           DISTRO_NAME: "centos"
           DISTRO_VER: "7"
 
@@ -199,14 +199,14 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.1"
-          DISTRO_NAME: "centos"
+          CUDA_VER: "11.5.2"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.6"
-          CUDA_VER: "11.6.0"
-          DISTRO_NAME: "centos"
+          CUDA_VER: "11.6.2"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
@@ -253,14 +253,14 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.1"
-          DISTRO_NAME: "centos"
+          CUDA_VER: "11.5.2"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.6"
-          CUDA_VER: "11.6.0"
-          DISTRO_NAME: "centos"
+          CUDA_VER: "11.6.2"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,49 +43,10 @@ jobs:
           DISTRO_NAME: "centos"
           DISTRO_VER: "6"
 
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "10.0"
-          CUDA_VER: "10.0"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "6"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "10.1"
-          CUDA_VER: "10.1"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "6"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "10.2"
-          CUDA_VER: "10.2"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "6"
-
         - DOCKERIMAGE: linux-anvil-cos7-cuda
           DOCKERFILE: linux-anvil-cuda
           DOCKERTAG: "9.2"
           CUDA_VER: "9.2"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-cos7-cuda
-          DOCKERFILE: linux-anvil-cuda
-          DOCKERTAG: "10.0"
-          CUDA_VER: "10.0"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-cos7-cuda
-          DOCKERFILE: linux-anvil-cuda
-          DOCKERTAG: "10.1"
-          CUDA_VER: "10.1"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-cos7-cuda
-          DOCKERFILE: linux-anvil-cuda
-          DOCKERTAG: "10.2"
-          CUDA_VER: "10.2"
           DISTRO_NAME: "centos"
           DISTRO_VER: "7"
 
@@ -146,24 +107,6 @@ jobs:
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "9.2"
           CUDA_VER: "9.2"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "10.0"
-          CUDA_VER: "10.0"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "10.1"
-          CUDA_VER: "10.1"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "10.2"
-          CUDA_VER: "10.2"
           DISTRO_NAME: "centos"
           DISTRO_VER: "7"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.4"
-          CUDA_VER: "11.4.2"
+          CUDA_VER: "11.4.3"
           DISTRO_NAME: "centos"
           DISTRO_VER: "7"
 
@@ -133,7 +133,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.7"
-          CUDA_VER: "11.7.0"
+          CUDA_VER: "11.7.1"
           DISTRO_NAME: "centos"
           DISTRO_VER: "7"
 
@@ -193,7 +193,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.4"
-          CUDA_VER: "11.4.2"
+          CUDA_VER: "11.4.3"
           DISTRO_NAME: "centos"
           DISTRO_VER: "8"
 
@@ -211,7 +211,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.7"
-          CUDA_VER: "11.7.0"
+          CUDA_VER: "11.7.1"
           DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
@@ -247,7 +247,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.4"
-          CUDA_VER: "11.4.2"
+          CUDA_VER: "11.4.3"
           DISTRO_NAME: "centos"
           DISTRO_VER: "8"
 
@@ -265,7 +265,7 @@ jobs:
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.7"
-          CUDA_VER: "11.7.0"
+          CUDA_VER: "11.7.1"
           DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 


### PR DESCRIPTION
As [noted at the previous conda-forge meeting]( https://github.com/conda-forge/conda-forge.github.io/blob/main/src/orga/minutes/2023-06-14.md ), some of these Docker images are going away. Please see [this notice]( https://gitlab.com/nvidia/container-images/cuda/-/issues/209#note_1452067531 ) and [the container support policy]( https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/support-policy.md )

Have rebuilt all of the images currently include in this repo with [this GHA job]( https://github.com/conda-forge/docker-images/actions/runs/5422331357 ) to ensure we have the latest build.

Some of the images just require a minor version bump, which is relatively straightforward.

With some of the `arm64` & `ppc64le` images, they are now no longer available with CentOS 8. So have moved to UBI.

Most of these changes do not affect images that we are using to build packages in conda-forge. However there is one exception to this. The CUDA 10 images are going away. As we have already discussed dropping CUDA 10.x support in the same conda-forge meeting, this merely gives us a reason to pickup the pace. Refreshed PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1708 ) to help make that move