### PR TITLE
Remove caching of compilers

### DIFF
--- a/linux-anvil-aarch64-cuda/Dockerfile
+++ b/linux-anvil-aarch64-cuda/Dockerfile
@@ -83,27 +83,6 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-aarch64 \
-        conda-forge::binutils_linux-aarch64 \
-        conda-forge::gcc_impl_linux-aarch64 \
-        conda-forge::gcc_linux-aarch64 \
-        conda-forge::gfortran_impl_linux-aarch64 \
-        conda-forge::gfortran_linux-aarch64 \
-        conda-forge::gxx_impl_linux-aarch64 \
-        conda-forge::gxx_linux-aarch64 \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Download and cache CUDA related packages.
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate && \

--- a/linux-anvil-aarch64/Dockerfile
+++ b/linux-anvil-aarch64/Dockerfile
@@ -39,27 +39,6 @@ RUN yum update -y && \
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-aarch64 \
-        conda-forge::binutils_linux-aarch64 \
-        conda-forge::gcc_impl_linux-aarch64 \
-        conda-forge::gcc_linux-aarch64 \
-        conda-forge::gfortran_impl_linux-aarch64 \
-        conda-forge::gfortran_linux-aarch64 \
-        conda-forge::gxx_impl_linux-aarch64 \
-        conda-forge::gxx_linux-aarch64 \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -43,27 +43,6 @@ RUN yum update -y && \
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-64 \
-        conda-forge::binutils_linux-64 \
-        conda-forge::gcc_impl_linux-64 \
-        conda-forge::gcc_linux-64 \
-        conda-forge::gfortran_impl_linux-64 \
-        conda-forge::gfortran_linux-64 \
-        conda-forge::gxx_impl_linux-64 \
-        conda-forge::gxx_linux-64 \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.

--- a/linux-anvil-cos7-x86_64/Dockerfile
+++ b/linux-anvil-cos7-x86_64/Dockerfile
@@ -38,27 +38,6 @@ RUN yum update -y && \
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-64 \
-        conda-forge::binutils_linux-64 \
-        conda-forge::gcc_impl_linux-64 \
-        conda-forge::gcc_linux-64 \
-        conda-forge::gfortran_impl_linux-64 \
-        conda-forge::gfortran_linux-64 \
-        conda-forge::gxx_impl_linux-64 \
-        conda-forge::gxx_linux-64 \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Add a file for users to source to activate the `conda`
 # environment `base`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.

--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -70,27 +70,6 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-64 \
-        conda-forge::binutils_linux-64 \
-        conda-forge::gcc_impl_linux-64 \
-        conda-forge::gcc_linux-64 \
-        conda-forge::gfortran_impl_linux-64 \
-        conda-forge::gfortran_linux-64 \
-        conda-forge::gxx_impl_linux-64 \
-        conda-forge::gxx_linux-64 \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Download and cache CUDA related packages.
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate && \

--- a/linux-anvil-ppc64le-cuda/Dockerfile
+++ b/linux-anvil-ppc64le-cuda/Dockerfile
@@ -100,27 +100,6 @@ RUN rpm -e --nodeps --verbose gcc gcc-c++
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-ppc64le \
-        conda-forge::binutils_linux-ppc64le \
-        conda-forge::gcc_impl_linux-ppc64le \
-        conda-forge::gcc_linux-ppc64le \
-        conda-forge::gfortran_impl_linux-ppc64le \
-        conda-forge::gfortran_linux-ppc64le \
-        conda-forge::gxx_impl_linux-ppc64le \
-        conda-forge::gxx_linux-ppc64le \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
 # Download and cache CUDA related packages.
 RUN if [[ "$CUDA_VER" == "9.2" || "$CUDA_VER" == "10.0" || "$CUDA_VER" == "10.1" ]]; then \
         echo "`cudatoolkit` not available for CUDA_VER<10.2"; \

--- a/linux-anvil-ppc64le/Dockerfile
+++ b/linux-anvil-ppc64le/Dockerfile
@@ -38,28 +38,6 @@ RUN yum update -y && \
 COPY scripts/run_commands /opt/docker/bin/run_commands
 RUN /opt/docker/bin/run_commands
 
-# Download and cache new compiler packages.
-# Should speedup installation of them on CIs.
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate && \
-    conda create -n test --yes --quiet --download-only \
-        conda-forge::binutils_impl_linux-ppc64le \
-        conda-forge::binutils_linux-ppc64le \
-        conda-forge::gcc_impl_linux-ppc64le \
-        conda-forge::gcc_linux-ppc64le \
-        conda-forge::gfortran_impl_linux-ppc64le \
-        conda-forge::gfortran_linux-ppc64le \
-        conda-forge::gxx_impl_linux-ppc64le \
-        conda-forge::gxx_linux-ppc64le \
-        conda-forge::libgcc-ng \
-        conda-forge::libgfortran-ng \
-        conda-forge::libstdcxx-ng && \
-    conda remove --yes --quiet -n test --all && \
-    conda clean -tiy && \
-    chgrp -R lucky /opt/conda && \
-    chmod -R g=u /opt/conda
-
-
 # Add a file for users to source to activate the `conda`
 # environment `root`. Also add a file that wraps that for
 # use with the `ENTRYPOINT`.


### PR DESCRIPTION
These caches don't work usually because the version downloaded here is the newest while the feedstocks don't use the latest.

cc @h-vetinari 