### PR TITLE
Update to Miniforge 23.3.1-0

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -5,15 +5,15 @@ set -exo pipefail
 export additional_channel=""
 
 export miniforge_arch="$(uname -m)"
-export miniforge_version="22.9.0-0"
-export python_version="3.10"  # should match the one provided in mambaforge
-export condapkg="https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/Mambaforge-${miniforge_version}-Linux-${miniforge_arch}.sh"
+export miniforge_version="23.3.1-0"
+export python_version="3.10"  # should match the one provided in miniforge
+export condapkg="https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/Miniforge3-${miniforge_version}-Linux-${miniforge_arch}.sh"
 if [ "$(uname -m)" = "x86_64" ]; then
-   export conda_chksum="7049f5ebdd6e2aee7611874599ab14445cd63070cdb63db2e00ae0b90d7c6132"
+   export conda_chksum="9be723d231609919fa3e3bb06f899a9a9c22e92e570bada8129a1bf50fee8d73"
 elif [ "$(uname -m)" = "ppc64le" ]; then
-   export conda_chksum="a17530e0e981991db5f6875e949dc22554f2ed0dd2b1bbb40ce677c910a2dc51"
+   export conda_chksum="434b461d309110bfeb72198541a541985aa197e3b605de27978c15f31d1520ef"
 elif [ "$(uname -m)" = "aarch64" ]; then
-   export conda_chksum="6076cfb0c2f88efa3e5e125dc54f3c0f8219cfe1ae9d9258a5abe42dbcf21a13"
+   export conda_chksum="b71277b8b40a6817d923fde0b858f56a4504f4e9b659d343dd8eae9d9473ab7f"
 else
    exit 1
 fi
@@ -47,7 +47,7 @@ conda config --show-sources
 # Update everything first
 mamba update --yes --all
 
-# Ensure conda build, deployment and docker tools ar present
+# Ensure conda build, deployment and docker tools are present
 mamba install --yes --quiet \
     "python=$python_version" \
     git \


### PR DESCRIPTION
The `run_commands` script was still pointing to an old version of Mambaforge (22.9). With https://github.com/conda-forge/miniforge/pull/277 now merged, it makes sense to standardize this across operating systems (macOS and Windows pull from latest Miniforge).