### PR TITLE
Use `conda`'s `libmamba` `solver`

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -41,6 +41,7 @@ source /opt/conda/etc/profile.d/conda.sh
 conda activate
 conda config --set show_channel_urls True
 conda config --set channel_priority strict
+conda config --set solver libmamba
 conda config ${additional_channel} --add channels conda-forge
 conda config --show-sources
 


### PR DESCRIPTION
Now that `conda-libmamba-solver` ships with the installer. Opt-in to using the `libmamba` `solver` with `conda`.