### PR TITLE
Move rest of CUDA arch images to UBI 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,31 +94,31 @@ jobs:
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.0"
           CUDA_VER: "11.0.3"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.1"
           CUDA_VER: "11.1.1"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.2"
           CUDA_VER: "11.2.2"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.3"
           CUDA_VER: "11.3.1"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.4"
           CUDA_VER: "11.4.3"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
@@ -148,31 +148,31 @@ jobs:
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.0"
           CUDA_VER: "11.0.3"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.1"
           CUDA_VER: "11.1.1"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.2"
           CUDA_VER: "11.2.2"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.3"
           CUDA_VER: "11.3.1"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.4"
           CUDA_VER: "11.4.3"
-          DISTRO_NAME: "centos"
+          DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda


### PR DESCRIPTION
The CUDA `aarch64le` & `ppc64le` CentOS 8 images are no longer available. So move them to UBI 8 based images, which are still around. This is what was done for the other CUDA images already ( https://github.com/conda-forge/docker-images/pull/237 ).