### PR TITLE
Update qemu-user-static to version 8.0.4

### DIFF
--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-if [ "$(uname -m)" == "x86_64" ]; then
+if [ "$(uname -m)" = "x86_64" ]; then
     docker run --rm --privileged multiarch/qemu-user-static:register --reset
 fi
 

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -23,19 +23,3 @@ d7d7dcbaf1a2a58fc3a42465ae5a253b1cef1bcb08c6e8bb8dd22be8cfdaadeb  qemu-arm-stati
 79a95114ab8b6f7d6d570bd6eeb81d8ed57f4d5210503a826a13fa26502a3bee  qemu-ppc64le-static
 e9c1ee2d9bf7e9aea9f59fd39837084f2c223676e656a5261f893b2de1b4e7bb  qemu-s390x-static
 EOF
-
-## If the download from Debian above has issues, we can use the one from Fedora below.
-## (This needs bsdtar installed.)
-# version='8.1.2'
-# build='1.fc40'
-# for arch in aarch64 arm ppc64le s390x; do
-#     curl -sL \
-#         "https://kojipkgs.fedoraproject.org//packages/qemu/${version}/${build}/x86_64/qemu-user-static-${arch/ppc64le/ppc}-${version}-${build}.x86_64.rpm" |
-#         bsdtar -xf- --strip-components=3 ./usr/bin/qemu-${arch}-static
-# done
-# sha256sum --check << 'EOF'
-# 955be1e1f1e0ed1f5180d35db92012be558bd860d90a189276b445b6ba9a46c9  qemu-aarch64-static
-# 1cda1ab3586fb74ef99d7f1903a1cdf405432a41dd1da39841592f9cdc72aa44  qemu-arm-static
-# 02b20dbf38e69a12d942c5fb1477160bab9da3fd428246e8fe011a2adced0fb6  qemu-ppc64le-static
-# 9e7d91557640d5ff4209f5894d2e648373752bdb7b664038ceddc371044b79e4  qemu-s390x-static
-# EOF

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -8,14 +8,12 @@ fi
 
 rm -f qemu-*-static
 
-set -- aarch64 arm ppc64le s390x
-
 version='8.1.2'
 build='ds-1'
 curl -sL \
     "http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}+${build}_amd64.deb" |
     dpkg-deb --extract - ./deb-tmp
-for arch; do
+for arch in aarch64 arm ppc64le s390x; do
     mv "./deb-tmp/usr/bin/qemu-${arch}-static" ./
 done
 rm -rf ./deb-tmp
@@ -30,7 +28,7 @@ EOF
 ## (This needs bsdtar installed.)
 # version='8.1.2'
 # build='1.fc40'
-# for arch; do
+# for arch in aarch64 arm ppc64le s390x; do
 #     curl -sL \
 #         "https://kojipkgs.fedoraproject.org//packages/qemu/${version}/${build}/x86_64/qemu-user-static-${arch/ppc64le/ppc}-${version}-${build}.x86_64.rpm" |
 #         bsdtar -xf- --strip-components=3 ./usr/bin/qemu-${arch}-static

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -11,29 +11,33 @@ rm -f qemu-*-static
 set -- aarch64 arm ppc64le s390x
 
 version='8.1.2'
-build='1.fc40'
+build='ds-1'
+curl -sL \
+    "http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}+${build}_amd64.deb" |
+    dpkg-deb --extract - ./deb-tmp
 for arch; do
-    curl -sL \
-        "https://kojipkgs.fedoraproject.org//packages/qemu/${version}/${build}/x86_64/qemu-user-static-${arch/ppc64le/ppc}-${version}-${build}.x86_64.rpm" |
-        bsdtar -xf- --strip-components=3 ./usr/bin/qemu-${arch}-static
+    mv "./deb-tmp/usr/bin/qemu-${arch}-static" ./
 done
+rm -rf ./deb-tmp
 sha256sum --check << 'EOF'
-955be1e1f1e0ed1f5180d35db92012be558bd860d90a189276b445b6ba9a46c9  qemu-aarch64-static
-1cda1ab3586fb74ef99d7f1903a1cdf405432a41dd1da39841592f9cdc72aa44  qemu-arm-static
-02b20dbf38e69a12d942c5fb1477160bab9da3fd428246e8fe011a2adced0fb6  qemu-ppc64le-static
-9e7d91557640d5ff4209f5894d2e648373752bdb7b664038ceddc371044b79e4  qemu-s390x-static
+f5c0f9f9e1499c6907bb293a250d9a015ea99e304654e0ab9fb38fd72efad7ce  qemu-aarch64-static
+d7d7dcbaf1a2a58fc3a42465ae5a253b1cef1bcb08c6e8bb8dd22be8cfdaadeb  qemu-arm-static
+79a95114ab8b6f7d6d570bd6eeb81d8ed57f4d5210503a826a13fa26502a3bee  qemu-ppc64le-static
+e9c1ee2d9bf7e9aea9f59fd39837084f2c223676e656a5261f893b2de1b4e7bb  qemu-s390x-static
 EOF
 
-## If the download from Fedora above has issues, we can use the one from Debian below.
+## If the download from Debian above has issues, we can use the one from Fedora below.
+## (This needs bsdtar installed.)
 # version='8.1.2'
-# build='ds-1'
-# curl -sL \
-# "http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}+${build}_amd64.deb" |
-#     bsdtar -xOf-  data.tar.xz |
-#     bsdtar -xf- --strip-components=3 $(printf './usr/bin/qemu-%s-static\n' "${@}")
+# build='1.fc40'
+# for arch; do
+#     curl -sL \
+#         "https://kojipkgs.fedoraproject.org//packages/qemu/${version}/${build}/x86_64/qemu-user-static-${arch/ppc64le/ppc}-${version}-${build}.x86_64.rpm" |
+#         bsdtar -xf- --strip-components=3 ./usr/bin/qemu-${arch}-static
+# done
 # sha256sum --check << 'EOF'
-# f5c0f9f9e1499c6907bb293a250d9a015ea99e304654e0ab9fb38fd72efad7ce  qemu-aarch64-static
-# d7d7dcbaf1a2a58fc3a42465ae5a253b1cef1bcb08c6e8bb8dd22be8cfdaadeb  qemu-arm-static
-# 79a95114ab8b6f7d6d570bd6eeb81d8ed57f4d5210503a826a13fa26502a3bee  qemu-ppc64le-static
-# e9c1ee2d9bf7e9aea9f59fd39837084f2c223676e656a5261f893b2de1b4e7bb  qemu-s390x-static
+# 955be1e1f1e0ed1f5180d35db92012be558bd860d90a189276b445b6ba9a46c9  qemu-aarch64-static
+# 1cda1ab3586fb74ef99d7f1903a1cdf405432a41dd1da39841592f9cdc72aa44  qemu-arm-static
+# 02b20dbf38e69a12d942c5fb1477160bab9da3fd428246e8fe011a2adced0fb6  qemu-ppc64le-static
+# 9e7d91557640d5ff4209f5894d2e648373752bdb7b664038ceddc371044b79e4  qemu-s390x-static
 # EOF

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -13,9 +13,7 @@ build='ds-1'
 curl -sL \
     "http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}+${build}_amd64.deb" |
     dpkg-deb --extract - ./deb-tmp
-for arch in aarch64 arm ppc64le s390x; do
-    mv "./deb-tmp/usr/bin/qemu-${arch}-static" ./
-done
+mv ./deb-tmp/usr/bin/qemu-*-static ./
 rm -rf ./deb-tmp
 sha256sum --check << 'EOF'
 f5c0f9f9e1499c6907bb293a250d9a015ea99e304654e0ab9fb38fd72efad7ce  qemu-aarch64-static

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -17,7 +17,6 @@ mv ./deb-tmp/usr/bin/qemu-*-static ./
 rm -rf ./deb-tmp
 sha256sum --check << 'EOF'
 f5c0f9f9e1499c6907bb293a250d9a015ea99e304654e0ab9fb38fd72efad7ce  qemu-aarch64-static
-d7d7dcbaf1a2a58fc3a42465ae5a253b1cef1bcb08c6e8bb8dd22be8cfdaadeb  qemu-arm-static
 79a95114ab8b6f7d6d570bd6eeb81d8ed57f4d5210503a826a13fa26502a3bee  qemu-ppc64le-static
 e9c1ee2d9bf7e9aea9f59fd39837084f2c223676e656a5261f893b2de1b4e7bb  qemu-s390x-static
 EOF

--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -8,15 +8,15 @@ fi
 
 rm -f qemu-*-static
 
-version='8.1.2'
-build='ds-1'
+version='8.0.4'
+build='dfsg-1ubuntu5'
 curl -sL \
-    "http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}+${build}_amd64.deb" |
+    "https://mirrors.edge.kernel.org/ubuntu/pool/universe/q/qemu/qemu-user-static_${version}%2B${build}_amd64.deb" |
     dpkg-deb --extract - ./deb-tmp
 mv ./deb-tmp/usr/bin/qemu-*-static ./
 rm -rf ./deb-tmp
 sha256sum --check << 'EOF'
-f5c0f9f9e1499c6907bb293a250d9a015ea99e304654e0ab9fb38fd72efad7ce  qemu-aarch64-static
-79a95114ab8b6f7d6d570bd6eeb81d8ed57f4d5210503a826a13fa26502a3bee  qemu-ppc64le-static
-e9c1ee2d9bf7e9aea9f59fd39837084f2c223676e656a5261f893b2de1b4e7bb  qemu-s390x-static
+0312d58f7f2e5825c84d9c39e686da8a2714728c5ed5b872716f06e189e6bbaa  qemu-aarch64-static
+6a9cc7d3d1a931811b1b91bbff83fb0bbfb0fb06cf8b7b980afad2ee55e3d06a  qemu-ppc64le-static
+8cf7e22ce2038cb36d9d0a9c49118e76a7fe6ab5d9c27d595b6815acc4b3bfac  qemu-s390x-static
 EOF

--- a/linux-anvil-alma/Dockerfile
+++ b/linux-anvil-alma/Dockerfile
@@ -17,7 +17,6 @@ ENV LANG en_US.UTF-8
 
 # Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
 ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
-ADD qemu-arm-static /usr/bin/qemu-arm-static
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 ADD qemu-s390x-static /usr/bin/qemu-s390x-static
 

--- a/linux-anvil-comp7/Dockerfile
+++ b/linux-anvil-comp7/Dockerfile
@@ -14,7 +14,6 @@ ENV LANG en_US.UTF-8
 
 # Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
 ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
-ADD qemu-arm-static /usr/bin/qemu-arm-static
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 ADD qemu-s390x-static /usr/bin/qemu-s390x-static
 

--- a/linux-anvil-cos7-x86_64/Dockerfile
+++ b/linux-anvil-cos7-x86_64/Dockerfile
@@ -14,7 +14,6 @@ ENV LANG en_US.UTF-8
 
 # Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
 ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
-ADD qemu-arm-static /usr/bin/qemu-arm-static
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 ADD qemu-s390x-static /usr/bin/qemu-s390x-static
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
closes gh-245
closes gh-228

<!--
Please add any other relevant info below:
-->
The GitHub repo we pulled the binaries from before is not updated as mentioned by @h-vetinari in https://github.com/conda-forge/docker-images/issues/245#issue-2000753010 .
This now downloads the binaries from Fedora (or Debian).