### PR TITLE
add rattler-build to installed tools

### DIFF
--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -75,6 +75,7 @@ mamba install --yes --quiet \
     anaconda-client \
     su-exec \
     pixi \
+    rattler-build \
     tini
 
 # Clean to reduce image size


### PR DESCRIPTION
I wanted to do some testing with rattler-build and CUDA locally. If possible, it would be nice to start including it :)