### PR TITLE
Drop old CUDA 11.x images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,34 +42,6 @@ jobs:
           SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on aarch64"
 
         - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.4"
-          CUDA_VER: "11.4.3"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.2"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.6"
-          CUDA_VER: "11.6.2"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.7"
-          CUDA_VER: "11.7.1"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.8"
           CUDA_VER: "11.8.0"
           DISTRO_NAME: "centos"
@@ -77,67 +49,11 @@ jobs:
           SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.4"
-          CUDA_VER: "11.4.3"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.2"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.6"
-          CUDA_VER: "11.6.2"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.7"
-          CUDA_VER: "11.7.1"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.8"
           CUDA_VER: "11.8.0"
           DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
           SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.4"
-          CUDA_VER: "11.4.3"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.5"
-          CUDA_VER: "11.5.2"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.6"
-          CUDA_VER: "11.6.2"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.7"
-          CUDA_VER: "11.7.1"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.8"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,34 +42,6 @@ jobs:
           SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on aarch64"
 
         - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.0"
-          CUDA_VER: "11.0.3"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.1"
-          CUDA_VER: "11.1.1"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.2"
-          CUDA_VER: "11.2.2"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
-          DOCKERTAG: "11.3"
-          CUDA_VER: "11.3.1"
-          DISTRO_NAME: "centos"
-          DISTRO_VER: "7"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-cuda
           DOCKERTAG: "11.4"
           CUDA_VER: "11.4.3"
           DISTRO_NAME: "centos"
@@ -105,34 +77,6 @@ jobs:
           SHORT_DESCRIPTION: "conda-forge build image for Cent0S 7 on x86_64 with CUDA"
 
         - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.0"
-          CUDA_VER: "11.0.3"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.1"
-          CUDA_VER: "11.1.1"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.2"
-          CUDA_VER: "11.2.2"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
-          DOCKERTAG: "11.3"
-          CUDA_VER: "11.3.1"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-ppc64le-cuda
           DOCKERTAG: "11.4"
           CUDA_VER: "11.4.3"
           DISTRO_NAME: "ubi"
@@ -166,34 +110,6 @@ jobs:
           DISTRO_NAME: "ubi"
           DISTRO_VER: "8"
           SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on ppc64le with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.0"
-          CUDA_VER: "11.0.3"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.1"
-          CUDA_VER: "11.1.1"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.2"
-          CUDA_VER: "11.2.2"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
-
-        - DOCKERIMAGE: linux-anvil-aarch64-cuda
-          DOCKERTAG: "11.3"
-          CUDA_VER: "11.3.1"
-          DISTRO_NAME: "ubi"
-          DISTRO_VER: "8"
-          SHORT_DESCRIPTION: "conda-forge build image for Cent0S 8 on aarch64 with CUDA"
 
         - DOCKERIMAGE: linux-anvil-aarch64-cuda
           DOCKERTAG: "11.4"


### PR DESCRIPTION
Follows up on the discussion in issue ( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/5339 ) and [this announcement]( https://conda-forge.org/news/2024/03/06/dropping-cuda-112/ )

As the CUDA 11.0-11.3 images are deprecated and planned for removal as noted in [this comment]( https://gitlab.com/nvidia/container-images/cuda/-/issues/209#note_1641845842 ), this goes ahead and drops those

Further as CUDA 11.8 is becoming the new minimum in conda-forge ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5799 ), this drops all of the CUDA images before 11.8

For CUDA 12.x we use the normal conda-forge images

Thus should bring the CUDA image builds here down to one build per architecture. All of which are building CUDA 11.8 images. Simplifying the build matrix here