### PR TITLE
Drop `devtoolset` reference in AlmaLinux comment

### DIFF
--- a/linux-anvil-alma/Dockerfile
+++ b/linux-anvil-alma/Dockerfile
@@ -49,7 +49,7 @@ COPY linux-anvil-alma/entrypoint_source /opt/docker/bin/entrypoint_source
 COPY scripts/entrypoint /opt/docker/bin/entrypoint
 
 # Ensure that all containers start with tini and the user selected process.
-# Activate the `conda` environment `base` and the devtoolset compiler.
+# Activate the `conda` environment `base`.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
The `devtoolset` compilers are no longer used (especially not in AlmaLinux builds where they have never been used). So drop this reference from this comment.