### PR TITLE
Bump QEMU to 8.2.7 (missing 8.2.4 binaries)

### DIFF
--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -21,7 +21,7 @@ DEBIAN_FRONTEND=noninteractive \
 # prefer non-`.0` patch releases to try to avoid potential new regressions;
 # if possible, check https://gitlab.com/qemu-project/qemu/-/issues
 # for relevant issues in old vs new version;
-version='8.2.4'
+version='8.2.7'
 build='1.fc40'
 for arch in aarch64 ppc64le s390x; do
     curl -sL \
@@ -30,7 +30,7 @@ for arch in aarch64 ppc64le s390x; do
 done
 
 sha256sum --check << 'EOF'
-5fb1ae8235807b310000ed3a1b03d49a000c51ec1a1f84869720b87273976466  qemu-aarch64-static
-4d9e1b1fc7e51d6bee4e087e06c1185cadc2d85b1308e802ed15c754ff6475cc  qemu-ppc64le-static
-3454f16b26dc94fcce23e4e2f97ab98033b659ad491675235c2388521154afac  qemu-s390x-static
+537131cbd6596728165e2036c9269e19e575a95d518c805d4462d865c63263eb  qemu-aarch64-static
+2ed243a429e4c994515f64c8b2b7b81bc1d2d77eaec4c0de67e393bd914d154d  qemu-ppc64le-static
+06d6bcd11b9a13770d1aa2120f37d842b67656d033d99793d21eefcd7775ff51  qemu-s390x-static
 EOF


### PR DESCRIPTION
Recently the weekly cron jobs here [started failing]( https://github.com/conda-forge/docker-images/actions/runs/10757570540/job/29831758482 ). This appears related to in the QEMU preparation step

```
+ curl -sL https://kojipkgs.fedoraproject.org/packages/qemu/8.2.4/1.fc40/x86_64/qemu-user-static-aarch64-8.2.4-1.fc40.x86_64.rpm
+ bsdtar -xf- --strip-components=3 ./usr/bin/qemu-aarch64-static
bsdtar: Error opening archive: Unrecognized archive format
```

However when following the URL back, it appears upstream has [dropped the 8.2.4 binaries]( https://kojipkgs.fedoraproject.org/packages/qemu/8.2.4/ )

<img width="1840" alt="Screenshot 2024-09-24 at 6 38 34 PM" src="https://github.com/user-attachments/assets/3de37b3b-ff70-45eb-9d6d-0e27a86c13cb">

Also it appears there have been a few QEMU patch releases recently

To fix CI and update QEMU, this switches to the latest QEMU 8.2 patch release, which is 8.2.7

There is also a QEMU 9.0.0 and 9.1.0. However the goal here primarily is to fix CI builds, have stuck with the latest 8.2. Perhaps an upgrade to QEMU 9 can be evaluated separately