### PR TITLE
Drop `conda remove` for non-existent env

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -80,7 +80,6 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda create -n test --yes --quiet --download-only \
         conda-forge::cudatoolkit=${CUDA_VER} \
         && \
-    conda remove --yes --quiet -n test --all && \
     conda clean -tiy && \
     chgrp -R lucky /opt/conda && \
     chmod -R g=u /opt/conda


### PR DESCRIPTION
Previously `conda create --download-only` would still create an empty environment even when using `--download-only`. Not entirely sure when this got fixed.

However we know it did as `conda remove` now errors if an environment does not exist ( https://github.com/conda-forge/docker-images/pull/284#issuecomment-2387717756 ), which we are now seeing on CI ( https://github.com/conda-forge/docker-images/pull/284 ). The reason this only started happening now is `conda` version `24.9.0` was only just packaged on conda-forge earlier today ( https://github.com/conda-forge/conda-feedstock/pull/240 )

Given this, simply drop the unneeded `conda remove` line to fix the CI error