### PR TITLE
Enable CRB repo on alma9, PowerTools on alma8

### DIFF
--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -18,15 +18,21 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "ubi8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+  ls -l /etc/yum.repos.d
+  cat /etc/yum.repos.d/AlmaLinux-PowerTools.repo
   # PowerTools repo not enabled by default
   sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/AlmaLinux-PowerTools.repo
+  cat /etc/yum.repos.d/AlmaLinux-PowerTools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
   # RPM key; re-enable it. Details: https://access.redhat.com/articles/3666211
   update-crypto-policies --set LEGACY
   rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
+  ls -l /etc/yum.repos.d
+  cat /etc/yum.repos.d/AlmaLinux-CRB.repo
   # PowerTools repo changed name to CRB in alma9
   sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/AlmaLinux-CRB.repo
+  cat /etc/yum.repos.d/AlmaLinux-CRB.repo
 fi
 
 rm -rf "/tmp/rpm-repos"

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -25,7 +25,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   sed -i '/^enabled=/d' /etc/yum.repos.d/almalinux-powertools.repo
   # for the [powertools] section, append `enabled=1` after that line
   sed -i '/^\[powertools\]/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
-  # but for [powertools-{source,debug}] sections, append `enabled=0`
+  # for [powertools-{source,debuginfo}] sections, append `enabled=0`
   sed -i '/^\[powertools-/a\enabled=0' /etc/yum.repos.d/almalinux-powertools.repo
   cat /etc/yum.repos.d/almalinux-powertools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -21,7 +21,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   ls -l /etc/yum.repos.d
   cat /etc/yum.repos.d/almalinux-powertools.repo
   # PowerTools repo not enabled by default
-  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
+  sed -i '/^enabled=/d; /^\[powertools\]/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
   cat /etc/yum.repos.d/almalinux-powertools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
@@ -31,7 +31,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   ls -l /etc/yum.repos.d
   cat /etc/yum.repos.d/almalinux-crb.repo
   # PowerTools repo changed name to CRB in alma9
-  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/almalinux-crb.repo
+  sed -i '/^enabled=/d; /^\[crb\]/a\enabled=1' /etc/yum.repos.d/almalinux-crb.repo
   cat /etc/yum.repos.d/almalinux-crb.repo
 fi
 

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -21,7 +21,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   ls -l /etc/yum.repos.d
   cat /etc/yum.repos.d/almalinux-powertools.repo
   # PowerTools repo not enabled by default
-  sed -i '/^enabled=/d; /^\[powertools\]/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
+  sed -i '/^enabled=/d; /^\[powertools\]/a\enabled=1; /^\[powertools-/a\enabled=0' /etc/yum.repos.d/almalinux-powertools.repo
   cat /etc/yum.repos.d/almalinux-powertools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
@@ -31,7 +31,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   ls -l /etc/yum.repos.d
   cat /etc/yum.repos.d/almalinux-crb.repo
   # PowerTools repo changed name to CRB in alma9
-  sed -i '/^enabled=/d; /^\[crb\]/a\enabled=1' /etc/yum.repos.d/almalinux-crb.repo
+  sed -i '/^enabled=/d; /^\[crb\]/a\enabled=1; /^\[crb-/a\enabled=0' /etc/yum.repos.d/almalinux-crb.repo
   cat /etc/yum.repos.d/almalinux-crb.repo
 fi
 

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -18,8 +18,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "ubi8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
-  ls -l /etc/yum.repos.d
-  cat /etc/yum.repos.d/almalinux-powertools.repo
+
   # PowerTools repo not enabled by default;
   # remove all `enabled=` lines
   sed -i '/^enabled=/d' /etc/yum.repos.d/almalinux-powertools.repo
@@ -27,19 +26,16 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   sed -i '/^\[powertools\]/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
   # for [powertools-{source,debuginfo}] sections, append `enabled=0`
   sed -i '/^\[powertools-/a\enabled=0' /etc/yum.repos.d/almalinux-powertools.repo
-  cat /etc/yum.repos.d/almalinux-powertools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
   # RPM key; re-enable it. Details: https://access.redhat.com/articles/3666211
   update-crypto-policies --set LEGACY
   rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
-  ls -l /etc/yum.repos.d
-  cat /etc/yum.repos.d/almalinux-crb.repo
+
   # PowerTools repo changed name to CRB in alma9
   sed -i '/^enabled=/d' /etc/yum.repos.d/almalinux-crb.repo
   sed -i '/^\[crb\]/a\enabled=1' /etc/yum.repos.d/almalinux-crb.repo
   sed -i '/^\[crb-/a\enabled=0' /etc/yum.repos.d/almalinux-crb.repo
-  cat /etc/yum.repos.d/almalinux-crb.repo
 fi
 
 rm -rf "/tmp/rpm-repos"

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -20,8 +20,13 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
   ls -l /etc/yum.repos.d
   cat /etc/yum.repos.d/almalinux-powertools.repo
-  # PowerTools repo not enabled by default
-  sed -i '/^enabled=/d; /^\[powertools\]/a\enabled=1; /^\[powertools-/a\enabled=0' /etc/yum.repos.d/almalinux-powertools.repo
+  # PowerTools repo not enabled by default;
+  # remove all `enabled=` lines
+  sed -i '/^enabled=/d' /etc/yum.repos.d/almalinux-powertools.repo
+  # for the [powertools] section, append `enabled=1` after that line
+  sed -i '/^\[powertools\]/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
+  # but for [powertools-{source,debug}] sections, append `enabled=0`
+  sed -i '/^\[powertools-/a\enabled=0' /etc/yum.repos.d/almalinux-powertools.repo
   cat /etc/yum.repos.d/almalinux-powertools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
@@ -31,7 +36,9 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   ls -l /etc/yum.repos.d
   cat /etc/yum.repos.d/almalinux-crb.repo
   # PowerTools repo changed name to CRB in alma9
-  sed -i '/^enabled=/d; /^\[crb\]/a\enabled=1; /^\[crb-/a\enabled=0' /etc/yum.repos.d/almalinux-crb.repo
+  sed -i '/^enabled=/d' /etc/yum.repos.d/almalinux-crb.repo
+  sed -i '/^\[crb\]/a\enabled=1' /etc/yum.repos.d/almalinux-crb.repo
+  sed -i '/^\[crb-/a\enabled=0' /etc/yum.repos.d/almalinux-crb.repo
   cat /etc/yum.repos.d/almalinux-crb.repo
 fi
 

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -18,11 +18,15 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "ubi8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+  # PowerTools repo not enabled by default
+  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/AlmaLinux-PowerTools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
   # RPM key; re-enable it. Details: https://access.redhat.com/articles/3666211
   update-crypto-policies --set LEGACY
   rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
+  # PowerTools repo changed name to CRB in alma9
+  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/AlmaLinux-CRB.repo
 fi
 
 rm -rf "/tmp/rpm-repos"

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -19,20 +19,20 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "ubi8" ]; then
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
   ls -l /etc/yum.repos.d
-  cat /etc/yum.repos.d/AlmaLinux-PowerTools.repo
+  cat /etc/yum.repos.d/almalinux-powertools.repo
   # PowerTools repo not enabled by default
-  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/AlmaLinux-PowerTools.repo
-  cat /etc/yum.repos.d/AlmaLinux-PowerTools.repo
+  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
+  cat /etc/yum.repos.d/almalinux-powertools.repo
 elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
   # RPM key; re-enable it. Details: https://access.redhat.com/articles/3666211
   update-crypto-policies --set LEGACY
   rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
   ls -l /etc/yum.repos.d
-  cat /etc/yum.repos.d/AlmaLinux-CRB.repo
+  cat /etc/yum.repos.d/almalinux-crb.repo
   # PowerTools repo changed name to CRB in alma9
-  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/AlmaLinux-CRB.repo
-  cat /etc/yum.repos.d/AlmaLinux-CRB.repo
+  sed -i '/^enabled=/d; /^\[/a\enabled=1' /etc/yum.repos.d/almalinux-crb.repo
+  cat /etc/yum.repos.d/almalinux-crb.repo
 fi
 
 rm -rf "/tmp/rpm-repos"


### PR DESCRIPTION
With the switch to alma8 & alma9, some of our CDTs are now split across separate repos. In particular, we need `PowerTools` on alma8, resp. `CRB` on alma9 (which is essentially the same thing but got renamed). See for example https://github.com/conda-forge/cdt-builds/commit/e118347a73c4927c902aff7b928fa1dfafa65782

As an example, the following failed:
```
+ /usr/bin/sudo -n yum install -y wget m4 help2man patch gcc-gfortran gcc-c++ rsync sed findutils make file strace
AlmaLinux 9 - AppStream                          30 MB/s | 9.2 MB     00:00    
AlmaLinux 9 - BaseOS                            3.2 MB/s | 4.5 MB     00:01    
AlmaLinux 9 - Extras                             86 kB/s |  13 kB     00:00    
No match for argument: help2man
```
That package is [available](https://almalinux.pkgs.org/9/almalinux-crb-x86_64/help2man-1.48.2-3.el9.noarch.rpm.html) under `CRB` on alma9, so enable this repo.