### PR TITLE
Drop cache buster step

### DIFF
--- a/linux-anvil-cuda/Dockerfile
+++ b/linux-anvil-cuda/Dockerfile
@@ -24,10 +24,6 @@ ENV LANGUAGE en_US.UTF-8
 # Set path to CUDA install (this is a symlink to /usr/local/cuda-${CUDA_VER})
 ENV CUDA_HOME /usr/local/cuda
 
-# bust the docker cache so that we always rerun the installs below
-# ADD https://loripsum.net/api /opt/docker/etc/gibberish
-ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
-
 # Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
 ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -18,10 +18,6 @@ ENV DISTRO_ARCH=${DISTRO_ARCH} \
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-# bust the docker cache so that we always rerun the installs below
-# ADD https://loripsum.net/api /opt/docker/etc/gibberish
-ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
-
 # Add qemu in here so that we can use this image on regular linux hosts with qemu user installed
 ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static


### PR DESCRIPTION
When we did builds on DockerHub or other external Docker providers, we needed a way to bust the cache in the `Dockerfile` itself. However now we do the builds on our own CI and simply push them to external providers. We already disable the cache when we do this build on CI. Plus builds start on fresh VMs without the old layers. Given this, let's simplify and drop the flaky cache busting step.