### PR TITLE
add alma10 images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,30 @@ jobs:
             DISTRO_VER: "9"
             SHORT_DESCRIPTION: "conda-forge build image for Alma 9 on ppc64le"
 
+          - DOCKERIMAGE: linux-anvil-x86_64
+            DOCKERFILE: linux-anvil
+            DOCKERTAG: "alma10"
+            DISTRO_ARCH: "amd64"
+            DISTRO_NAME: "almalinux"
+            DISTRO_VER: "10"
+            SHORT_DESCRIPTION: "conda-forge build image for Alma 10 on x86_64"
+
+          - DOCKERIMAGE: linux-anvil-aarch64
+            DOCKERFILE: linux-anvil
+            DOCKERTAG: "alma10"
+            DISTRO_ARCH: "arm64"
+            DISTRO_NAME: "almalinux"
+            DISTRO_VER: "10"
+            SHORT_DESCRIPTION: "conda-forge build image for Alma 10 on aarch64"
+
+          - DOCKERIMAGE: linux-anvil-ppc64le
+            DOCKERFILE: linux-anvil
+            DOCKERTAG: "alma10"
+            DISTRO_ARCH: "ppc64le"
+            DISTRO_NAME: "almalinux"
+            DISTRO_VER: "10"
+            SHORT_DESCRIPTION: "conda-forge build image for Alma 10 on ppc64le"
+
     env:
       DOCKERIMAGE: ${{ matrix.cfg.DOCKERIMAGE }}
       DOCKERFILE: ${{ matrix.cfg.DOCKERFILE }}

--- a/scripts/fix_rpm
+++ b/scripts/fix_rpm
@@ -26,7 +26,7 @@ elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux8" ]; then
   sed -i '/^\[powertools\]/a\enabled=1' /etc/yum.repos.d/almalinux-powertools.repo
   # for [powertools-{source,debuginfo}] sections, append `enabled=0`
   sed -i '/^\[powertools-/a\enabled=0' /etc/yum.repos.d/almalinux-powertools.repo
-elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" ]; then
+elif [ "${DISTRO_NAME}${DISTRO_VER}" = "almalinux9" || "${DISTRO_NAME}${DISTRO_VER}" = "almalinux10" ]; then
   # alma9 removed SHA1 availability by default, but it's still needed for the
   # RPM key; re-enable it. Details: https://access.redhat.com/articles/3666211
   update-crypto-policies --set LEGACY


### PR DESCRIPTION
Necessary for https://github.com/conda-forge/linux-sysroot-feedstock/pull/92, which has already been requested for a while, and will also be necessary for riscv64 support that was discussed in the last core call