### PR TITLE
MNT: Specify arm64/v8 architecture variant

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           - DOCKERIMAGE: linux-anvil-aarch64
             DOCKERFILE: linux-anvil
             DOCKERTAG: "cos7"
-            DISTRO_ARCH: "arm64"
+            DISTRO_ARCH: "arm64/v8"
             DISTRO_NAME: "centos"
             DISTRO_VER: "7"
             SHORT_DESCRIPTION: "conda-forge build image for CentOS 7 on aarch64"
@@ -76,7 +76,7 @@ jobs:
             DOCKERFILE: linux-anvil-cuda
             DOCKERTAG: "ubi8"
             CUDA_VER: "11.8.0"
-            DISTRO_ARCH: "arm64"
+            DISTRO_ARCH: "arm64/v8"
             DISTRO_NAME: "ubi"
             DISTRO_VER: "8"
             SHORT_DESCRIPTION: "conda-forge build image for UBI 8 on aarch64 with CUDA 11.8"
@@ -92,7 +92,7 @@ jobs:
           - DOCKERIMAGE: linux-anvil-aarch64
             DOCKERFILE: linux-anvil
             DOCKERTAG: "alma8"
-            DISTRO_ARCH: "arm64"
+            DISTRO_ARCH: "arm64/v8"
             DISTRO_NAME: "almalinux"
             DISTRO_VER: "8"
             SHORT_DESCRIPTION: "conda-forge build image for Alma 8 on aarch64"
@@ -116,7 +116,7 @@ jobs:
           - DOCKERIMAGE: linux-anvil-aarch64
             DOCKERFILE: linux-anvil
             DOCKERTAG: "alma9"
-            DISTRO_ARCH: "arm64"
+            DISTRO_ARCH: "arm64/v8"
             DISTRO_NAME: "almalinux"
             DISTRO_VER: "9"
             SHORT_DESCRIPTION: "conda-forge build image for Alma 9 on aarch64"
@@ -140,7 +140,7 @@ jobs:
           - DOCKERIMAGE: linux-anvil-aarch64
             DOCKERFILE: linux-anvil
             DOCKERTAG: "alma10"
-            DISTRO_ARCH: "arm64"
+            DISTRO_ARCH: "arm64/v8"
             DISTRO_NAME: "almalinux"
             DISTRO_VER: "10"
             SHORT_DESCRIPTION: "conda-forge build image for Alma 10 on aarch64"

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -30,7 +30,7 @@ ADD qemu-s390x-static /usr/bin/qemu-s390x-static
 
 # (arm64v8/centos:7 only) Fix language override to get a working en_US.UTF-8 locale; backports:
 # https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670
-RUN if [ "${DISTRO_ARCH}" = "arm64" ] && [ "${DISTRO_NAME}${DISTRO_VER}" = "centos7" ]; then \
+RUN if [ "${DISTRO_ARCH}" = "arm64/v8" ] && [ "${DISTRO_NAME}${DISTRO_VER}" = "centos7" ]; then \
         sed -i 's/override_install_langs=en_US\.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf ; \
     fi
 


### PR DESCRIPTION
Resolves https://github.com/conda-forge/docker-images/issues/326

* As Docker manifests include the architecture variant in the manifest for Linux aarch64 platforms, for `linux-aarch64` builds the architecture specified in `DISTRO_ARCH` should be `arm64/v8`.

Examples:
```console
$ crane manifest fedora:latest | jq '.manifests[] | select(.platform.architecture == "arm64") | .platform'
{
  "architecture": "arm64",
  "os": "linux",
  "variant": "v8"
}
$ crane config quay.io/condaforge/linux-anvil-aarch64:latest | jq '{os, architecture, variant}'
{
  "os": "linux",
  "architecture": "arm64",
  "variant": "v8"
}
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [N/A] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [N/A] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
