### PR TITLE
Add qemu-riscv64-static from Fedora repositories

### DIFF
--- a/download-qemu-static.sh
+++ b/download-qemu-static.sh
@@ -23,9 +23,15 @@ DEBIAN_FRONTEND=noninteractive \
 # for relevant issues in old vs new version;
 version='8.2.8'
 build='2.fc40'
-for arch in aarch64 ppc64le s390x; do
+for arch in aarch64 ppc64le s390x riscv64; do
+    pkg_arch="${arch}"
+    if [[ "${arch}" == 'ppc64le' ]]; then
+        pkg_arch='ppc'
+    elif [[ "${arch}" == 'riscv64' ]]; then
+        pkg_arch='riscv'
+    fi
     curl -sL \
-        "https://kojipkgs.fedoraproject.org/packages/qemu/${version}/${build}/x86_64/qemu-user-static-${arch/ppc64le/ppc}-${version}-${build}.x86_64.rpm" |
+        "https://kojipkgs.fedoraproject.org/packages/qemu/${version}/${build}/x86_64/qemu-user-static-${pkg_arch}-${version}-${build}.x86_64.rpm" |
         bsdtar -xf- --strip-components=3 ./usr/bin/qemu-${arch}-static
 done
 
@@ -33,4 +39,5 @@ sha256sum --check << 'EOF'
 c41cd478bdcccbc76a0e35db8ba65861038cd8f0d6339abc0cfd19eadc335fc6  qemu-aarch64-static
 9b5c44f35eceaf6484ec11bc03047001293586f9ae73861dde87329243d56ae7  qemu-ppc64le-static
 767a23c0ec4570b28d352ad00c55c4fc2315d5707078d022c1d2cc07d827561e  qemu-s390x-static
+c71ac58f8749dc5334fc85d92ffb1bb41e54ebb143b7a79e9eac95d7efe283ca  qemu-riscv64-static
 EOF

--- a/linux-anvil/Dockerfile
+++ b/linux-anvil/Dockerfile
@@ -27,6 +27,7 @@ ADD https://www.random.org/cgi-bin/randbyte?nbytes=4096&format=h /opt/docker/etc
 ADD qemu-aarch64-static /usr/bin/qemu-aarch64-static
 ADD qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 ADD qemu-s390x-static /usr/bin/qemu-s390x-static
+ADD qemu-riscv64-static /usr/bin/qemu-riscv64-static
 
 # (arm64v8/centos:7 only) Fix language override to get a working en_US.UTF-8 locale; backports:
 # https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670

--- a/scripts/run_commands
+++ b/scripts/run_commands
@@ -21,6 +21,9 @@ elif [ "$(uname -m)" = "aarch64" ]; then
    export conda_chksum="7bf60bce50f57af7ea4500b45eeb401d9350011ab34c9c45f736647d8dba9021"
    export micromamba_arch="aarch64"
    export micromamba_chksum="7803a2aa51a5f0a58f3d2ef0f07724edb67f31f61b3e44ae9b8d6c9f009f7996"
+elif [ "$(uname -m)" = "riscv64" ]; then
+   echo "not supported yet; see https://github.com/conda-forge/conda-forge.github.io/issues/1744"
+   exit 1
 else
    exit 1
 fi


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Relates to https://github.com/conda-forge/conda-forge.github.io/issues/1744